### PR TITLE
Axioms: Relax disjointness criteria for singleton

### DIFF
--- a/00-matching-logic.mm0
+++ b/00-matching-logic.mm0
@@ -253,10 +253,10 @@ axiom KT {X: SVar} (phi psi: Pattern X):
   $ (mu X phi) -> psi $;
 axiom existence {x: EVar}: $ exists x (eVar x) $;
 axiom singleton {box1 box2: SVar} {x: EVar}
-  (ctx1: Pattern box1 x) (ctx2: Pattern box2 x) (phi: Pattern x):
+  (ctx1 ctx2 phi: Pattern box1 box2 x):
   $ ~(app[ (eVar x) /\ phi / box1 ] ctx1 /\ app[ (eVar x) /\ ~phi / box2 ] ctx2) $;
 axiom singleton_same_var {box: SVar} {x: EVar}
-  (ctx1 ctx2: Pattern box x) (phi: Pattern x):
+  (ctx1 ctx2 phi: Pattern box x):
   $ ~(app[ (eVar x) /\ phi / box ] ctx1 /\ app[ (eVar x) /\ ~phi / box ] ctx2) $;
 
 

--- a/02-ml-normalization.mm1
+++ b/02-ml-normalization.mm1
@@ -152,8 +152,7 @@ theorem framing_norm {box: SVar} (ctx: Pattern box) (phi1 phi2 rho1 rho2: Patter
   (h3: $ phi1 -> phi2 $):
   $ rho1 -> rho2 $ = '(norm (norm_imp h1 h2) @ framing h3);
 theorem singleton_norm {box1 box2: SVar} {x: EVar}
-  (ctx1 rho1: Pattern box1 x) (ctx2 rho2: Pattern box2 x)
-  (phi: Pattern x)
+  (ctx1 rho1 ctx2 rho2 phi: Pattern box1 box2 x)
   (h1: $ Norm (app[ (eVar x) /\ phi / box1 ] ctx1) rho1 $)
   (h2: $ Norm (app[ (eVar x) /\ ~phi / box2 ] ctx2) rho2 $):
   $ ~(rho1 /\ rho2) $ =

--- a/12-proof-system-p.mm1
+++ b/12-proof-system-p.mm1
@@ -325,12 +325,10 @@ theorem lemma_ceil_exists_membership:
   '(bitr (cong_of_equiv_def lemma_exists_and) @
     ibii propag_exists_def prop_43_exists_def);
 
-theorem lemma_56 {box: SVar} (ctx: Pattern box) (phi: Pattern):
-  $ (app[ phi / box ] ctx) -> |^ phi ^| $ =
-  '(rsyl (rsyl
-    (framing @ anl lemma_exists_and)
-    propag_exists_strict)
-    (exists_generalization_strict @ rsyl
+theorem lemma_56 {box: SVar} (phi ctx: Pattern box)
+: $ (app[ phi / box ] ctx) -> |^ phi ^| $ =
+  '(rsyl (rsyl (framing @ anl lemma_exists_and) @ propag_exists eFresh_triv)
+    (exists_generalization eFresh_triv @ rsyl
       (dne @ singleton_norm norm_refl (! defNorm box2))
       (propag_or_def @ framing_def (anl com12b @ rsyl dne @ imim2i dne) (! definedness x))
     ));


### PR DESCRIPTION
In general, all context related axioms/theorems should allow the `box` variable anywhere, since `box` is bound by the app context and is immediately substituted away.