### PR TITLE
Freshness axioms & prove top-implies-fp

### DIFF
--- a/00-matching-logic.mm0
+++ b/00-matching-logic.mm0
@@ -179,9 +179,9 @@ axiom sSubstitution_in_imp {X: SVar} (psi phi1 phi2: Pattern X):
   $ Norm (s[ psi / X ] (phi1 -> phi2)) ((s[ psi / X ] phi1) -> (s[ psi / X ] phi2)) $;
 axiom sSubstitution_in_app {X: SVar} (psi phi1 phi2: Pattern X):
   $ Norm (s[ psi / X ] app phi1 phi2) (app (s[ psi / X ] phi1) (s[ psi / X ] phi2)) $;
-axiom sSubstitution_in_exists {X: SVar} (psi: Pattern X) {x: EVar} (phi: Pattern X x):
+axiom sSubstitution_in_exists {X: SVar} {x: EVar} (phi psi: Pattern X x):
+  $ _eFresh x psi $ >
   $ Norm (s[ psi / X ] exists x phi) (exists x (s[ psi / X ] phi)) $;
--- TODO: ditto
 axiom sSubstitution_in_mu {X Y: SVar} (psi phi: Pattern X Y):
   $ _sFresh Y psi $ >
   $ Norm (s[ psi / X ] mu Y phi) (mu Y (s[ psi / X ] phi)) $;

--- a/00-matching-logic.mm0
+++ b/00-matching-logic.mm0
@@ -206,12 +206,6 @@ axiom norm_ctxApp_pt {box: SVar} (ctx ctx2 phi phi2: Pattern box):
   $ Norm phi phi2 $ >
   $ Norm (ctxApp box ctx phi) (ctxApp box ctx2 phi2) $;
 
--- TODO: Are these necessary?
--- axiom exists_alpha {x y: EVar} (phi: Pattern x):
---   $ Norm (exists x phi) (exists y (e[ eVar y / x ] phi)) $;
--- axiom mu_alpha {X Y: SVar} (phi: Pattern X):
---   $ Norm (mu X phi) (mu Y (s[ sVar Y / X ] phi)) $;
-
 -- The Proof System of Matching Logic
 axiom norm (phi psi: Pattern):
   $ Norm phi psi $ >

--- a/00-matching-logic.mm0
+++ b/00-matching-logic.mm0
@@ -49,7 +49,7 @@ def nu {X: SVar} (phi: Pattern X): Pattern = $ ~(mu X (~ s[ ~ sVar X / X ] phi))
 term _Positive {X: SVar}: Pattern X > Positivity;
 term _Negative {X: SVar}: Pattern X > Positivity;
 
-axiom positive_triv {X: SVar} (phi: Pattern): $ _Positive X phi $;
+axiom positive_disjoint {X: SVar} (phi: Pattern): $ _Positive X phi $;
 axiom positive_in_same_sVar {X: SVar}: $ _Positive X (sVar X) $;
 axiom positive_in_imp {X: SVar} (phi1 phi2: Pattern X):
   $ _Negative X phi1 $ > $ _Positive X phi2 $ > $ _Positive X (phi1 -> phi2) $;
@@ -61,7 +61,7 @@ axiom positive_in_mu {X: SVar} {Y: SVar} (phi: Pattern X Y):
   $ _Positive X phi $ > $ _Positive X (mu Y phi) $;
 axiom positive_in_same_mu {X: SVar} (phi: Pattern X): $ _Positive X (mu X phi) $;
 
-axiom negative_triv {X: SVar} (phi: Pattern): $ _Negative X phi $;
+axiom negative_disjoint {X: SVar} (phi: Pattern): $ _Negative X phi $;
 axiom negative_in_imp {X: SVar} (phi1 phi2: Pattern X):
   $ _Positive X phi1 $ > $ _Negative X phi2 $ > $ _Negative X (phi1 -> phi2) $;
 axiom negative_in_app {X: SVar} (phi1 phi2: Pattern X):
@@ -76,7 +76,7 @@ axiom negative_in_same_mu {X: SVar} (phi: Pattern X): $ _Negative X (mu X phi) $
 term _eFresh {x: EVar}: Pattern x > Freshness;
 -- term _sFresh: SVar > Pattern > Freshness;
 
-axiom eFresh_triv {x: EVar} (phi: Pattern): $ _eFresh x phi $;
+axiom eFresh_disjoint {x: EVar} (phi: Pattern): $ _eFresh x phi $;
 axiom eFresh_imp {x: EVar} (phi1 phi2: Pattern x):
   $ _eFresh x phi1 $ >
   $ _eFresh x phi2 $ >
@@ -114,7 +114,7 @@ axiom eFresh_appCtx {x: EVar} {box: SVar} (ctx psi: Pattern x box):
 -- Definition of substitutions and application contexts as meta-level relations
 term Norm: Pattern > Pattern > Normalization;
 
-axiom eSubstitution_triv {x: EVar} (phi: Pattern) (psi: Pattern x): $ Norm (e[ psi / x ] phi) phi $;
+axiom eSubstitution_disjoint {x: EVar} (phi: Pattern) (psi: Pattern x): $ Norm (e[ psi / x ] phi) phi $;
 axiom eSubstitution_in_same_eVar {x: EVar} (psi: Pattern x): $ Norm (e[ psi / x ] eVar x) psi $;
 axiom eSubstitution_in_imp {x: EVar} (psi phi1 phi2: Pattern x):
   $ Norm (e[ psi / x ] (phi1 -> phi2)) ((e[ psi / x ] phi1) -> e[ psi / x ] phi2) $;
@@ -138,7 +138,7 @@ axiom eSubstitution_in_sSubst {x: EVar} {X: SVar} (psi1 psi2 phi: Pattern x X):
 axiom eSubstitution_in_appCtx {x: EVar} {box: SVar} (psi1 psi2 phi: Pattern x box):
   $ Norm (e[ psi1 / x ] app[ psi2 / box ] phi) (app[ (e[ psi1 / x ] psi2) / box ] e[ psi1 / x ] phi) $;
 
-axiom sSubstitution_triv {X: SVar} (phi: Pattern) (psi: Pattern X): $ Norm (s[ psi / X ]  phi) phi $;
+axiom sSubstitution_disjoint {X: SVar} (phi: Pattern) (psi: Pattern X): $ Norm (s[ psi / X ]  phi) phi $;
 axiom sSubstitution_in_same_sVar {X: SVar} (psi: Pattern X): $ Norm (s[ psi / X ] sVar X) psi $;
 axiom sSubstitution_in_imp {X: SVar} (psi phi1 phi2: Pattern X):
   $ Norm (s[ psi / X ] (phi1 -> phi2)) ((s[ psi / X ] phi1) -> (s[ psi / X ] phi2)) $;

--- a/00-matching-logic.mm0
+++ b/00-matching-logic.mm0
@@ -196,13 +196,13 @@ axiom sSubstitution_in_sSubst {X Y: SVar} (psi1 psi2 phi: Pattern X Y):
 axiom sSubstitution_in_appCtx {X box: SVar} (psi1 psi2 phi: Pattern X box):
   $ Norm (s[ psi1 / X ] app[ psi2 / box ] phi) (app[ (s[ psi1 / X ] psi2) / box ] s[ psi1 / X ] phi) $;
 
-axiom appCtxVar {box: SVar} (phi: Pattern): $ Norm (app[ phi / box ] sVar box) phi $;
-axiom appCtxL {box: SVar} (ctx: Pattern box) (phi1 phi2: Pattern):
+axiom appCtxVar {box: SVar} (phi: Pattern box): $ Norm (app[ phi / box ] sVar box) phi $;
+axiom appCtxL {box: SVar} (phi1 phi2 ctx: Pattern box) :
   $ Norm (app[ phi1 / box ] (app ctx phi2)) (app (app[ phi1 / box ] ctx) phi2) $;
-axiom appCtxR {box: SVar} (ctx: Pattern box) (phi1 phi2: Pattern):
+axiom appCtxR {box: SVar} (phi1 phi2 ctx: Pattern box) :
   $ Norm (app[ phi2 / box ] (app phi1 ctx)) (app phi1 (app[ phi2 / box ] ctx)) $;
 -- TODO: Do we need to propagate app[] through the other substitution constructs?
-axiom appCtxNested {box1 box2: SVar} (ctx1 phi: Pattern box1) (ctx2: Pattern box2):
+axiom appCtxNested {box1 box2: SVar} (ctx1 ctx2 phi: Pattern box1 box2):
   $ Norm (app[ phi / box2 ] app[ ctx2 / box1 ] ctx1) (app[ app[ phi / box2 ] ctx2 / box1 ] ctx1) $;
 
 axiom norm_refl (phi: Pattern): $ Norm phi phi $;

--- a/00-matching-logic.mm0
+++ b/00-matching-logic.mm0
@@ -182,7 +182,8 @@ axiom sSubstitution_in_app {X: SVar} (psi phi1 phi2: Pattern X):
 axiom sSubstitution_in_exists {X: SVar} (psi: Pattern X) {x: EVar} (phi: Pattern X x):
   $ Norm (s[ psi / X ] exists x phi) (exists x (s[ psi / X ] phi)) $;
 -- TODO: ditto
-axiom sSubstitution_in_mu_disjoint {X: SVar} (psi: Pattern X) {Y: SVar} (phi: Pattern X Y):
+axiom sSubstitution_in_mu {X Y: SVar} (psi phi: Pattern X Y):
+  $ _sFresh Y psi $ >
   $ Norm (s[ psi / X ] mu Y phi) (mu Y (s[ psi / X ] phi)) $;
 axiom sSubstitution_in_same_mu {X: SVar} (psi phi: Pattern X):
   $ Norm (s[ psi / X ] mu X phi) (mu X phi) $;

--- a/00-matching-logic.mm0
+++ b/00-matching-logic.mm0
@@ -72,10 +72,8 @@ axiom negative_in_mu {X: SVar} {Y: SVar} (phi: Pattern X Y):
   $ _Negative X phi $ > $ _Negative X (mu Y phi) $;
 axiom negative_in_same_mu {X: SVar} (phi: Pattern X): $ _Negative X (mu X phi) $;
 
--- Freshness definitions
+-- Freshness for Element Variables
 term _eFresh {x: EVar}: Pattern x > Freshness;
--- term _sFresh: SVar > Pattern > Freshness;
-
 axiom eFresh_disjoint {x: EVar} (phi: Pattern): $ _eFresh x phi $;
 axiom eFresh_imp {x: EVar} (phi1 phi2: Pattern x):
   $ _eFresh x phi1 $ >
@@ -109,7 +107,44 @@ axiom eFresh_appCtx {x: EVar} {box: SVar} (ctx psi: Pattern x box):
   $ _eFresh x psi $ >
   $ _eFresh x (app[ psi / box ] ctx) $;
 
--- TODO: define freshness for set variables too?
+-- Freshness for Set Variables
+term _sFresh: SVar > Pattern > Freshness;
+axiom sFresh_disjoint {X: SVar} (phi: Pattern): $ _sFresh X phi $;
+axiom sFresh_imp {X: SVar} (phi1 phi2: Pattern X):
+  $ _sFresh X phi1 $ >
+  $ _sFresh X phi2 $ >
+  $ _sFresh X (phi1 -> phi2) $;
+axiom sFresh_app {X: SVar} (phi1 phi2: Pattern X):
+  $ _sFresh X phi1 $ >
+  $ _sFresh X phi2 $ >
+  $ _sFresh X (app phi1 phi2) $;
+axiom sFresh_exists {X : SVar} {y: EVar} (phi: Pattern X y):
+  $ _sFresh X phi $ >
+  $ _sFresh X (exists y phi) $;
+axiom sFresh_mu_same_var {X: SVar} (phi: Pattern X):
+  $ _sFresh X (mu X phi) $;
+axiom sFresh_mu {X Y: SVar} (phi: Pattern X Y):
+  $ _sFresh X phi $ >
+  $ _sFresh X (mu Y phi) $;
+axiom sFresh_eSubst {X: SVar} {y: EVar} (phi psi: Pattern X y):
+  $ _sFresh X phi $ >
+  $ _sFresh X psi $ >
+  $ _sFresh X (e[ psi / y ] phi) $;
+axiom sFresh_sSubst_same_var {X: SVar} (phi psi: Pattern X):
+  $ _sFresh X psi $ >
+  $ _sFresh X (s[ psi / X ] phi) $;
+axiom sFresh_sSubst {X Y: SVar} (phi psi: Pattern X Y):
+  $ _sFresh X phi $ >
+  $ _sFresh X psi $ >
+  $ _sFresh X (s[ psi / Y ] phi) $;
+axiom sFresh_appCtx {X box: SVar} (ctx psi: Pattern X box):
+  $ _sFresh X ctx $ >
+  $ _sFresh X psi $ >
+  $ _sFresh X (app[ psi / box ] ctx) $;
+--- Since the box variable is immediately plugged away, it is free in app contexts. 
+axiom sFresh_appCtx_box {box: SVar} (ctx psi: Pattern box):
+  $ _sFresh box psi $ >
+  $ _sFresh box (app[ psi / box ] ctx) $;
 
 -- Definition of substitutions and application contexts as meta-level relations
 term Norm: Pattern > Pattern > Normalization;

--- a/00-matching-logic.mm0
+++ b/00-matching-logic.mm0
@@ -147,9 +147,8 @@ axiom sSubstitution_in_app {X: SVar} (psi phi1 phi2: Pattern X):
 axiom sSubstitution_in_exists {X: SVar} (psi: Pattern X) {x: EVar} (phi: Pattern X x):
   $ Norm (s[ psi / X ] exists x phi) (exists x (s[ psi / X ] phi)) $;
 -- TODO: ditto
-axiom sSubstitution_in_mu {X: SVar} (psi: Pattern X) {Y: SVar} (phi: Pattern X Y):
+axiom sSubstitution_in_mu_disjoint {X: SVar} (psi: Pattern X) {Y: SVar} (phi: Pattern X Y):
   $ Norm (s[ psi / X ] mu Y phi) (mu Y (s[ psi / X ] phi)) $;
--- TODO: ditto
 axiom sSubstitution_in_same_mu {X: SVar} (psi phi: Pattern X):
   $ Norm (s[ psi / X ] mu X phi) (mu X phi) $;
 axiom sSubstitution_in_eSubst {X: SVar} {x: EVar} (psi1 psi2 phi: Pattern x X):

--- a/00-matching-logic.mm0
+++ b/00-matching-logic.mm0
@@ -43,7 +43,7 @@ infixl and: $/\$ prec 33;
 def equiv (phi1 phi2: Pattern): Pattern = $ (phi1 -> phi2) /\ (phi2 -> phi1) $;
 infixl equiv: $<->$ prec 19;
 def forall {x: EVar} (phi: Pattern x): Pattern = $ ~(exists x (~phi)) $;
-def nu {X: SVar} (phi: Pattern X): Pattern = $ ~(mu X (~phi)) $;
+def nu {X: SVar} (phi: Pattern X): Pattern = $ ~(mu X (~ s[ ~ sVar X / X ] phi)) $;
 
 -- Positivity definitions
 term _Positive {X: SVar}: Pattern X > Positivity;

--- a/02-ml-normalization.mm1
+++ b/02-ml-normalization.mm1
@@ -31,13 +31,13 @@ theorem norm_imp_r (phi psi1 psi2: Pattern)
 theorem eFresh_not {x: EVar} (phi: Pattern x)
   (h: $ _eFresh x phi $):
   $ _eFresh x (~ phi) $ =
-  '(eFresh_imp h eFresh_triv);
+  '(eFresh_imp h eFresh_disjoint);
 theorem eSubstitution_in_not {x: EVar} (psi phi: Pattern x):
   $ Norm (e[ psi / x ] ~phi) (~e[ psi / x ] phi) $ =
-  '(norm_trans eSubstitution_in_imp @ norm_imp norm_refl eSubstitution_triv);
+  '(norm_trans eSubstitution_in_imp @ norm_imp norm_refl eSubstitution_disjoint);
 theorem sSubstitution_in_not {X: SVar} (psi phi: Pattern X):
   $ Norm (s[ psi / X ] ~phi) (~(s[ psi / X ] phi)) $ =
-  '(norm_trans sSubstitution_in_imp @ norm_imp norm_refl sSubstitution_triv);
+  '(norm_trans sSubstitution_in_imp @ norm_imp norm_refl sSubstitution_disjoint);
 
 --- or
 theorem norm_or (phi psi phi2 psi2: Pattern)
@@ -98,10 +98,10 @@ theorem norm_equiv_r (phi psi psi2: Pattern)
 theorem exists_generalization_strict {x: EVar} (phi1: Pattern x) (phi2: Pattern)
   (h: $ phi1 -> phi2 $):
   $ (exists x phi1) -> phi2 $ =
-  '(exists_generalization eFresh_triv h);
+  '(exists_generalization eFresh_disjoint h);
 theorem propag_exists_strict {box: SVar} {x: EVar} (ctx: Pattern box) (phi: Pattern x):
   $ app[ exists x phi / box ] ctx -> exists x (app[ phi / box ] ctx) $ =
-  '(propag_exists eFresh_triv);
+  '(propag_exists eFresh_disjoint);
 
 theorem exists_framing {x: EVar} (phi1 phi2: Pattern x)
   (h: $ phi1 -> phi2 $):
@@ -114,7 +114,7 @@ theorem or_exists_strict {x: EVar} (phi1: Pattern) (phi2: Pattern x):
     (eori
       (syl exists_intro_same_var orl)
       (exists_generalization eFresh_exists_same_var @ syl exists_intro_same_var orr))
-    (exists_generalization (eFresh_or eFresh_triv eFresh_exists_same_var) @ eori orl @ orrd exists_intro_same_var));
+    (exists_generalization (eFresh_or eFresh_disjoint eFresh_exists_same_var) @ eori orl @ orrd exists_intro_same_var));
 
 theorem imp_exists_strict {x: EVar} (phi1: Pattern) (phi2: Pattern x):
   $ (phi1 -> exists x phi2) <-> exists x (phi1 -> phi2) $ =
@@ -159,12 +159,12 @@ theorem singleton_norm {box1 box2: SVar} {x: EVar}
 
 -- propagation of eSubst
 do {
-  (def (propag_e_subst_adv x ctx wo_x) @ if (not (== (lookup wo_x ctx) #undef)) 'eSubstitution_triv @ match ctx
-    [$bot$     'eSubstitution_triv]
-    [$top$     'eSubstitution_triv]
-    [$sym ,S$  'eSubstitution_triv]
-    [$sVar ,X$ 'eSubstitution_triv]
-    [$eVar ,y$ (if (== x y) 'eSubstitution_in_same_eVar 'eSubstitution_triv)]
+  (def (propag_e_subst_adv x ctx wo_x) @ if (not (== (lookup wo_x ctx) #undef)) 'eSubstitution_disjoint @ match ctx
+    [$bot$     'eSubstitution_disjoint]
+    [$top$     'eSubstitution_disjoint]
+    [$sym ,S$  'eSubstitution_disjoint]
+    [$sVar ,X$ 'eSubstitution_disjoint]
+    [$eVar ,y$ (if (== x y) 'eSubstitution_in_same_eVar 'eSubstitution_disjoint)]
     [$imp ,phi1 ,phi2$     '(_eSubst_imp             ,(propag_e_subst_adv x phi1 wo_x) ,(propag_e_subst_adv x phi2 wo_x))]
     [$app ,phi1 ,phi2$     '(_eSubst_app             ,(propag_e_subst_adv x phi1 wo_x) ,(propag_e_subst_adv x phi2 wo_x))]
     [$exists ,y ,psi$ (if (== x y) 'eSubstitution_in_same_exists '(_eSubst_exists ,(propag_e_subst_adv x psi wo_x)))]
@@ -179,13 +179,13 @@ do {
     [$equiv ,phi1 ,phi2$   '(_eSubst_equiv           ,(propag_e_subst_adv x phi1 wo_x) ,(propag_e_subst_adv x phi2 wo_x))]
     [$_eq ,phi1 ,phi2$     '(_eSubst_eq              ,(propag_e_subst_adv x phi1 wo_x) ,(propag_e_subst_adv x phi2 wo_x))]
 
-    [$epsilon$     'eSubstitution_triv]
-    [$top_letter$  'eSubstitution_triv]
-    [$a$           'eSubstitution_triv]
-    [$b$           'eSubstitution_triv]
+    [$epsilon$     'eSubstitution_disjoint]
+    [$top_letter$  'eSubstitution_disjoint]
+    [$a$           'eSubstitution_disjoint]
+    [$b$           'eSubstitution_disjoint]
     [$concat ,psi1 ,psi2$ '(_eSubst_concat          ,(propag_e_subst_adv x psi1 wo_x) ,(propag_e_subst_adv x psi2 wo_x))]
-    [$top_word ,Y$ 'eSubstitution_triv]
-    [$kleene ,Y ,psi$ '(_eSubst_mu @ _eSubst_or eSubstitution_triv @ sSubst_concat ,(propag_e_subst_adv x psi wo_x) eSubstitution_triv)]
+    [$top_word ,Y$ 'eSubstitution_disjoint]
+    [$kleene ,Y ,psi$ '(_eSubst_mu @ _eSubst_or eSubstitution_disjoint @ sSubst_concat ,(propag_e_subst_adv x psi wo_x) eSubstitution_disjoint)]
     [$nnimp ,phi1 ,phi2$  '(_eSubst_nnimp           ,(propag_e_subst_adv x phi1 wo_x) ,(propag_e_subst_adv x phi2 wo_x))]
     [_             'norm_refl]
     -- [('e[ phi2 / y] psi) '()]
@@ -197,11 +197,11 @@ do {
   (def (propag_e_subst x ctx) @ propag_e_subst_adv x ctx (atom-map!))
 
   (def (propag_s_subst X ctx) @ match ctx
-    [$bot$     'sSubstitution_triv]
-    [$top$     'sSubstitution_triv]
-    [$sym ,S$  'sSubstitution_triv]
-    [$eVar ,x$ 'sSubstitution_triv]
-    [$sVar ,Y$ (if (== X Y) 'sSubstitution_in_same_sVar 'sSubstitution_triv)]
+    [$bot$     'sSubstitution_disjoint]
+    [$top$     'sSubstitution_disjoint]
+    [$sym ,S$  'sSubstitution_disjoint]
+    [$eVar ,x$ 'sSubstitution_disjoint]
+    [$sVar ,Y$ (if (== X Y) 'sSubstitution_in_same_sVar 'sSubstitution_disjoint)]
     [$imp ,phi1 ,phi2$    '(_sSubst_imp             ,(propag_s_subst X phi1) ,(propag_s_subst X phi2))]
     [$app ,phi1 ,phi2$    '(_sSubst_app             ,(propag_s_subst X phi1) ,(propag_s_subst X phi2))]
     [$exists ,y ,psi$     '(_sSubst_exists          ,(propag_s_subst X psi))]
@@ -215,15 +215,15 @@ do {
                           '(_eSubst_eSubst_same_var ,(propag_s_subst X psi1) ,(propag_s_subst X psi2))
                           (error "not implemented"))]
 
-    [$epsilon$    'sSubstitution_triv]
-    [$top_letter$ 'sSubstitution_triv]
-    [$a$          'sSubstitution_triv]
-    [$b$          'sSubstitution_triv]
+    [$epsilon$    'sSubstitution_disjoint]
+    [$top_letter$ 'sSubstitution_disjoint]
+    [$a$          'sSubstitution_disjoint]
+    [$b$          'sSubstitution_disjoint]
     [$concat ,psi1 ,psi2$ '(sSubst_concat          ,(propag_s_subst X psi1) ,(propag_s_subst X psi2))]
-    [$top_word ,Y$    (if (== X Y) 'sSubstitution_in_same_mu 'sSubstitution_triv)]
+    [$top_word ,Y$    (if (== X Y) 'sSubstitution_in_same_mu 'sSubstitution_disjoint)]
     [$kleene ,Y ,psi$ (if (== X Y)
                           'sSubstitution_in_same_mu
-                          '(_sSubst_mu_disjoint @ _sSubst_or sSubstitution_triv @ sSubst_concat ,(propag_s_subst X psi) sSubstitution_triv))]
+                          '(_sSubst_mu_disjoint @ _sSubst_or sSubstitution_disjoint @ sSubst_concat ,(propag_s_subst X psi) sSubstitution_disjoint))]
     [$nnimp ,phi1 ,phi2$  '(_sSubst_nnimp           ,(propag_s_subst X phi1) ,(propag_s_subst X phi2))]
     [_            'norm_refl]
     -- [('e[ phi2 / y] psi) '()]
@@ -260,7 +260,7 @@ theorem _sSubst_mu_disjoint {X Y: SVar} (psi rho: Pattern X Y) (phi: Pattern X)
 theorem _sSubst_not {X: SVar} (phi psi rho: Pattern X)
   (h: $ Norm (s[ phi / X ] psi) rho $):
   $ Norm (s[ phi / X ] (~ psi)) (~ rho) $ =
-  '(_sSubst_imp h sSubstitution_triv);
+  '(_sSubst_imp h sSubstitution_disjoint);
 
 theorem _sSubst_or {X: SVar} (phi phi1 phi2 psi1 psi2: Pattern X)
   (h1: $ Norm (s[ phi / X ] phi1) psi1 $)
@@ -311,7 +311,7 @@ theorem _eSubst_mu {x: EVar} {X: SVar} (psi rho: Pattern x X) (phi: Pattern x)
 theorem _eSubst_not {x: EVar} (phi psi rho: Pattern x)
   (h: $ Norm (e[ phi / x ] psi) rho $):
   $ Norm (e[ phi / x ] (~ psi)) (~ rho) $ =
-  '(_eSubst_imp h eSubstitution_triv);
+  '(_eSubst_imp h eSubstitution_disjoint);
 
 theorem _eSubst_or {x: EVar} (phi phi1 phi2 psi1 psi2: Pattern x)
   (h1: $ Norm (e[ phi / x ] phi1) psi1 $)

--- a/02-ml-normalization.mm1
+++ b/02-ml-normalization.mm1
@@ -204,7 +204,7 @@ do {
     [$sVar ,Y$ (if (== X Y) 'sSubstitution_in_same_sVar 'sSubstitution_disjoint)]
     [$imp ,phi1 ,phi2$    '(_sSubst_imp             ,(propag_s_subst X phi1) ,(propag_s_subst X phi2))]
     [$app ,phi1 ,phi2$    '(_sSubst_app             ,(propag_s_subst X phi1) ,(propag_s_subst X phi2))]
-    [$exists ,y ,psi$     '(_sSubst_exists          ,(propag_s_subst X psi))]
+    [$exists ,y ,psi$     '(_sSubst_exists_disjoint          ,(propag_s_subst X psi))]
     [$mu ,Y ,psi$ (if (== X Y) 
                           'sSubstitution_in_same_mu 
                           '(_sSubst_mu_disjoint     ,(propag_s_subst X psi)))]
@@ -274,7 +274,7 @@ theorem _sSubst_and {X: SVar} (phi phi1 phi2 psi1 psi2: Pattern X)
   $ Norm (s[ phi / X ] (phi1 /\ phi2)) (psi1 /\ psi2) $ =
   '(_sSubst_not @ _sSubst_imp h1 (_sSubst_not h2));
 
-theorem _sSubst_exists {X: SVar} {x: EVar} (psi rho: Pattern X x) (phi: Pattern X)
+theorem _sSubst_exists_disjoint {X: SVar} {x: EVar} (psi rho: Pattern X x) (phi: Pattern X)
   (h: $ Norm (s[ phi / X ] psi) rho $):
   $ Norm (s[ phi / X ] (exists x psi)) (exists x rho) $ =
   '(norm_trans sSubstitution_in_exists (norm_exists h));

--- a/02-ml-normalization.mm1
+++ b/02-ml-normalization.mm1
@@ -257,10 +257,16 @@ theorem _sSubst_imp {X: SVar} (phi phi1 phi2 psi1 psi2: Pattern X)
   $ Norm (s[ phi / X ] (phi1 -> phi2)) (psi1 -> psi2) $ =
   '(norm_trans sSubstitution_in_imp (norm_imp h1 h2));
 
+theorem _sSubst_mu {X Y: SVar} (phi psi rho: Pattern X Y)
+  (f : $ _sFresh Y phi $)
+  (h : $ Norm (s[ phi / X ] psi) rho $):
+  $ Norm (s[ phi / X ] (mu Y psi)) (mu Y rho) $
+  = '(norm_trans (sSubstitution_in_mu f) (norm_mu h));
+
 theorem _sSubst_mu_disjoint {X Y: SVar} (psi rho: Pattern X Y) (phi: Pattern X)
   (h : $ Norm (s[ phi / X ] psi) rho $):
   $ Norm (s[ phi / X ] (mu Y psi)) (mu Y rho) $
-  = '(norm_trans sSubstitution_in_mu_disjoint (norm_mu h));
+  = '(_sSubst_mu sFresh_disjoint h);
 
 theorem _sSubst_not {X: SVar} (phi psi rho: Pattern X)
   (h: $ Norm (s[ phi / X ] psi) rho $):

--- a/02-ml-normalization.mm1
+++ b/02-ml-normalization.mm1
@@ -5,6 +5,7 @@ import "01-propositional.mm1";
 --- Normalizations over various sugar
 -------------------------------------
 
+--- app
 theorem norm_app_l (phi phi1 phi2: Pattern)
   (h: $ Norm phi1 phi2 $):
   $ Norm (app phi1 phi) (app phi2 phi) $ =
@@ -13,12 +14,8 @@ theorem norm_app_r (phi phi1 phi2: Pattern)
   (h: $ Norm phi1 phi2 $):
   $ Norm (app phi phi1) (app phi phi2) $ =
   '(norm_app norm_refl h);
-theorem norm_app2 (phi phi1 phi2 psi1 psi2: Pattern)
-  (h1: $ Norm phi1 phi2 $)
-  (h2: $ Norm psi1 psi2 $):
-  $ Norm (app (app phi phi1) psi1) (app (app phi phi2) psi2) $ =
-  '(norm_app (norm_app norm_refl h1) h2);
 
+--- not
 theorem norm_not (phi phi2: Pattern)
   (h: $ Norm phi phi2 $):
   $ Norm (~phi) (~phi2) $ =

--- a/02-ml-normalization.mm1
+++ b/02-ml-normalization.mm1
@@ -255,7 +255,7 @@ theorem _sSubst_imp {X: SVar} (phi phi1 phi2 psi1 psi2: Pattern X)
 theorem _sSubst_mu_disjoint {X Y: SVar} (psi rho: Pattern X Y) (phi: Pattern X)
   (h : $ Norm (s[ phi / X ] psi) rho $):
   $ Norm (s[ phi / X ] (mu Y psi)) (mu Y rho) $
-  = '(norm_trans sSubstitution_in_mu (norm_mu h));
+  = '(norm_trans sSubstitution_in_mu_disjoint (norm_mu h));
 
 theorem _sSubst_not {X: SVar} (phi psi rho: Pattern X)
   (h: $ Norm (s[ phi / X ] psi) rho $):

--- a/02-ml-normalization.mm1
+++ b/02-ml-normalization.mm1
@@ -207,7 +207,7 @@ do {
     [$exists ,y ,psi$     '(_sSubst_exists          ,(propag_s_subst X psi))]
     [$mu ,Y ,psi$ (if (== X Y) 
                           'sSubstitution_in_same_mu 
-                          '(_sSubst_mu              ,(propag_s_subst X psi)))]
+                          '(_sSubst_mu_disjoint     ,(propag_s_subst X psi)))]
     [$not ,psi$           '(_sSubst_not             ,(propag_s_subst X psi))]
     [$or ,phi1 ,phi2$     '(_sSubst_or              ,(propag_s_subst X phi1) ,(propag_s_subst X phi2))]
     [$and ,phi1 ,phi2$    '(_sSubst_and             ,(propag_s_subst X phi1) ,(propag_s_subst X phi2))]
@@ -223,7 +223,7 @@ do {
     [$top_word ,Y$    (if (== X Y) 'sSubstitution_in_same_mu 'sSubstitution_triv)]
     [$kleene ,Y ,psi$ (if (== X Y)
                           'sSubstitution_in_same_mu
-                          '(_sSubst_mu @ _sSubst_or sSubstitution_triv @ sSubst_concat ,(propag_s_subst X psi) sSubstitution_triv))]
+                          '(_sSubst_mu_disjoint @ _sSubst_or sSubstitution_triv @ sSubst_concat ,(propag_s_subst X psi) sSubstitution_triv))]
     [$nnimp ,phi1 ,phi2$  '(_sSubst_nnimp           ,(propag_s_subst X phi1) ,(propag_s_subst X phi2))]
     [_            'norm_refl]
     -- [('e[ phi2 / y] psi) '()]
@@ -252,7 +252,7 @@ theorem _sSubst_imp {X: SVar} (phi phi1 phi2 psi1 psi2: Pattern X)
   $ Norm (s[ phi / X ] (phi1 -> phi2)) (psi1 -> psi2) $ =
   '(norm_trans sSubstitution_in_imp (norm_imp h1 h2));
 
-theorem _sSubst_mu {X Y: SVar} (psi rho: Pattern X Y) (phi: Pattern X)
+theorem _sSubst_mu_disjoint {X Y: SVar} (psi rho: Pattern X Y) (phi: Pattern X)
   (h : $ Norm (s[ phi / X ] psi) rho $):
   $ Norm (s[ phi / X ] (mu Y psi)) (mu Y rho) $
   = '(norm_trans sSubstitution_in_mu (norm_mu h));

--- a/02-ml-normalization.mm1
+++ b/02-ml-normalization.mm1
@@ -1,12 +1,6 @@
 import "00-matching-logic.mm0";
 import "01-propositional.mm1";
 
---- TODO: Remove me. We should instead be adding a positivity hypothesis
---- to each theorem that needs this.
-theorem sSubstitution_in_mu_disjoint {X: SVar} (psi: Pattern X) {Y: SVar} (phi: Pattern X Y):
-  $ Norm (s[ psi / X ] mu Y phi) (mu Y (s[ psi / X ] phi)) $
-= '(sSubstitution_in_mu sFresh_disjoint);
-
 --- Normalizations over various sugar
 -------------------------------------
 
@@ -107,6 +101,10 @@ theorem exists_generalization_strict {x: EVar} (phi1: Pattern x) (phi2: Pattern)
 theorem propag_exists_strict {box: SVar} {x: EVar} (ctx: Pattern box) (phi: Pattern x):
   $ app[ exists x phi / box ] ctx -> exists x (app[ phi / box ] ctx) $ =
   '(propag_exists eFresh_disjoint);
+
+theorem propag_or_bi {box: SVar} (ctx phi1 phi2: Pattern box):
+  $ (app[ phi1 \/ phi2 / box ] ctx) <-> (app[ phi1 / box ] ctx \/ app[ phi2 / box ] ctx) $
+= '(ibii  propag_or (eori (framing orl) (framing orr)));
 
 theorem exists_framing {x: EVar} (phi1 phi2: Pattern x)
   (h: $ phi1 -> phi2 $):

--- a/02-ml-normalization.mm1
+++ b/02-ml-normalization.mm1
@@ -1,6 +1,11 @@
 import "00-matching-logic.mm0";
 import "01-propositional.mm1";
 
+--- TODO: Remove me. We should instead be adding a positivity hypothesis
+--- to each theorem that needs this.
+theorem sSubstitution_in_mu_disjoint {X: SVar} (psi: Pattern X) {Y: SVar} (phi: Pattern X Y):
+  $ Norm (s[ psi / X ] mu Y phi) (mu Y (s[ psi / X ] phi)) $
+= '(sSubstitution_in_mu sFresh_disjoint);
 
 --- Normalizations over various sugar
 -------------------------------------
@@ -380,4 +385,3 @@ theorem norm_lemma_r
   (h2: $ phi -> psi $):
   $ phi -> rho $ =
   '(norm (norm_imp_r @ norm_sym h1) h2);
-

--- a/02-ml-normalization.mm1
+++ b/02-ml-normalization.mm1
@@ -279,10 +279,16 @@ theorem _sSubst_and {X: SVar} (phi phi1 phi2 psi1 psi2: Pattern X)
   $ Norm (s[ phi / X ] (phi1 /\ phi2)) (psi1 /\ psi2) $ =
   '(_sSubst_not @ _sSubst_imp h1 (_sSubst_not h2));
 
+theorem _sSubst_exists {X: SVar} {x: EVar} (phi psi rho: Pattern X x)
+  (f: $ _eFresh x phi $)
+  (h: $ Norm (s[ phi / X ] psi) rho $):
+  $ Norm (s[ phi / X ] (exists x psi)) (exists x rho) $ =
+  '(norm_trans (sSubstitution_in_exists f) (norm_exists h));
+
 theorem _sSubst_exists_disjoint {X: SVar} {x: EVar} (psi rho: Pattern X x) (phi: Pattern X)
   (h: $ Norm (s[ phi / X ] psi) rho $):
   $ Norm (s[ phi / X ] (exists x psi)) (exists x rho) $ =
-  '(norm_trans sSubstitution_in_exists (norm_exists h));
+  '(_sSubst_exists eFresh_disjoint h);
 
 theorem _eSubst_exists {x y: EVar} (psi rho: Pattern x y) (phi: Pattern x)
   (h: $ Norm (e[ phi / x ] psi) rho $):

--- a/12-proof-system-p.mm1
+++ b/12-proof-system-p.mm1
@@ -3,7 +3,7 @@ import "11-definedness-normalization.mm1";
 
 theorem negative_in_not {X: SVar} (phi: Pattern X)
   (h: $ _Positive X phi $): $ _Negative X (~ phi) $ =
-  '(negative_in_imp h negative_triv);
+  '(negative_in_imp h negative_disjoint);
 theorem positive_in_or {X: SVar} (phi1 phi2: Pattern X)
   (h1: $ _Positive X phi1 $)
   (h2: $ _Positive X phi2 $):
@@ -14,7 +14,7 @@ theorem positive_in_or {X: SVar} (phi1 phi2: Pattern X)
 theorem _eSubst_ceil {x: EVar} (phi psi rho: Pattern x)
   (h: $ Norm (e[ phi / x ] psi) rho $):
   $ Norm (e[ phi / x ] (|^ psi ^|)) (|^ rho ^|) $ =
-  '(_eSubst_app eSubstitution_triv h);
+  '(_eSubst_app eSubstitution_disjoint h);
 theorem _eSubst_floor {x: EVar} (phi psi rho: Pattern x)
   (h: $ Norm (e[ phi / x ] psi) rho $):
   $ Norm (e[ phi / x ] (|_ psi _|)) (|_ rho _|) $ =
@@ -44,7 +44,7 @@ theorem prop_43_or {box: SVar} (ctx: Pattern box) (phi1 phi2: Pattern):
   '(eori (framing orl) (framing orr));
 theorem prop_43_exists {box: SVar} {x: EVar} (ctx: Pattern box) (phi: Pattern box x):
   $ (exists x (app[ phi / box ] ctx)) -> app[ exists x phi / box ] ctx $ =
-  '(exists_generalization (eFresh_appCtx eFresh_triv eFresh_exists_same_var) (framing exists_intro_same_var));
+  '(exists_generalization (eFresh_appCtx eFresh_disjoint eFresh_exists_same_var) (framing exists_intro_same_var));
 
 theorem exists_appCtx {x: EVar} {box: SVar} (ctx: Pattern box) (phi: Pattern x):
   $ (app[ exists x phi / box ] ctx) <-> exists x (app[ phi / box ] ctx) $ =
@@ -55,7 +55,7 @@ theorem prop_43_or_def (phi1 phi2: Pattern):
   '(eori (framing_def orl) (framing_def orr));
 theorem prop_43_exists_def {x: EVar} (phi: Pattern x):
   $ (exists x (|^ phi ^|)) -> |^ exists x phi ^| $ =
-  '(exists_generalization (eFresh_app eFresh_triv eFresh_exists_same_var) (framing_def exists_intro_same_var));
+  '(exists_generalization (eFresh_app eFresh_disjoint eFresh_exists_same_var) (framing_def exists_intro_same_var));
 
 theorem appCtxLVar {box: SVar} (phi1 phi2: Pattern):
   $ Norm (app[ phi1 / box ] (app (sVar box) phi2)) (app phi1 phi2) $ =
@@ -84,7 +84,7 @@ theorem mu_framing {X: SVar} (phi1 phi2: Pattern X)
 theorem mu_framing_strict {X: SVar} (phi1 phi2: Pattern)
   (h: $ phi1 -> phi2 $):
   $ mu X phi1 -> mu X phi2 $ =
-  '(mu_framing positive_triv positive_triv h);
+  '(mu_framing positive_disjoint positive_disjoint h);
 
 --- prop_44
 theorem imp_cong_of_equiv_not: $(phi1 <-> phi2) -> (~phi1 <-> ~phi2)$ = 'noteq;
@@ -335,8 +335,8 @@ theorem lemma_ceil_exists_membership:
 
 theorem lemma_56 {box: SVar} (phi ctx: Pattern box)
 : $ (app[ phi / box ] ctx) -> |^ phi ^| $ =
-  '(rsyl (rsyl (framing @ anl lemma_exists_and) @ propag_exists eFresh_triv)
-    (exists_generalization eFresh_triv @ rsyl
+  '(rsyl (rsyl (framing @ anl lemma_exists_and) @ propag_exists eFresh_disjoint)
+    (exists_generalization eFresh_disjoint @ rsyl
       (dne @ singleton_norm norm_refl (! defNorm box2))
       (propag_or_def @ framing_def (anl com12b @ rsyl dne @ imim2i dne) (! definedness x))
     ));
@@ -381,7 +381,7 @@ theorem lemma_62_forward {x: EVar} (phi: Pattern):
 theorem lemma_62_reverse {y: EVar} (phi: Pattern) {.box: SVar}:
   $ phi -> (exists y ((y in phi) /\ eVar y))$
   = '( ! membership_elim x _
-     @ exists_generalization eFresh_triv
+     @ exists_generalization eFresh_disjoint
      @ notnot1
      @ membership_imp_reverse
      @ syl membership_exists_reverse
@@ -390,20 +390,20 @@ theorem lemma_62_reverse {y: EVar} (phi: Pattern) {.box: SVar}:
      @ syl (! exists_intro y x)
      @ norm (norm_imp norm_refl @ norm_sym @ norm_trans eSubstitution_in_and
                 @ norm_and (norm_trans eSubstitution_in_app @ norm_app
-                              eSubstitution_triv
-                            @ norm_trans eSubstitution_in_and @ norm_and eSubstitution_triv
-                            @ norm_trans eSubstitution_in_app @ norm_app eSubstitution_triv
+                              eSubstitution_disjoint
+                            @ norm_trans eSubstitution_in_and @ norm_and eSubstitution_disjoint
+                            @ norm_trans eSubstitution_in_app @ norm_app eSubstitution_disjoint
                             @ norm_trans eSubstitution_in_and @ norm_and
                               eSubstitution_in_same_eVar
-                              eSubstitution_triv)
+                              eSubstitution_disjoint)
                            ( norm_trans eSubstitution_in_not @ norm_not
-                            @ norm_trans eSubstitution_in_app @ norm_app eSubstitution_triv
+                            @ norm_trans eSubstitution_in_app @ norm_app eSubstitution_disjoint
                             @ norm_trans eSubstitution_in_not @ norm_not
                             @ norm_trans eSubstitution_in_and @ norm_and
                               (norm_trans eSubstitution_in_imp @ norm_imp
-                                 eSubstitution_triv eSubstitution_in_same_eVar )
+                                 eSubstitution_disjoint eSubstitution_in_same_eVar )
                               (norm_trans eSubstitution_in_imp @ norm_imp
-                                 eSubstitution_in_same_eVar eSubstitution_triv )   )
+                                 eSubstitution_in_same_eVar eSubstitution_disjoint )   )
             )
      @ iand ( syl (norm (norm_imp (norm_and defNorm norm_refl) @ defNorm) (! lemma_60_reverse _ box) )
             @ iand (a1i definedness)

--- a/13-fixedpoints.mm1
+++ b/13-fixedpoints.mm1
@@ -26,7 +26,7 @@ theorem propag_floor (phi psi ctx: Pattern box):
 
 theorem ctximp_in_ctx_forward {box: SVar} (ctx: Pattern box)
 : $app[ (ctximp_app box ctx psi dummy) / box ] ctx -> psi$
- = '(rsyl (propag_exists eFresh_triv) @ exists_generalization eFresh_triv @ rsyl propag_floor @ impcom @ rsyl corollary_57_floor id );
+ = '(rsyl (propag_exists eFresh_disjoint) @ exists_generalization eFresh_disjoint @ rsyl propag_floor @ impcom @ rsyl corollary_57_floor id );
 
 theorem wrap_lemma {x: EVar} (phi psi: Pattern x)
   (h: $ (x in phi) -> psi $):

--- a/21-words-helpers.mm1
+++ b/21-words-helpers.mm1
@@ -47,13 +47,21 @@ theorem eq_to_concat_bi
   (h2: $ (phi1 == phi2) -> (rho1 <-> rho2) $):
   $ (phi1 == phi2) -> ((psi1 . rho1) <-> (psi2 . rho2)) $ =
   '(eq_to_app_bi (eq_to_app_r_bi h1) h2);
-theorem appctx_concat_l : $ Norm (app[ phi / box ] (sVar box . psi)) (phi . psi)$
+
+theorem norm_concat
+  (h1: $Norm phi1 phi2$)
+  (h2: $Norm psi1 psi2$)
+: $ Norm (phi1 . psi1) (phi2 . psi2)$
+= '(norm_app (norm_app norm_refl h1) h2);
+
+theorem appctx_concat_l (phi psi : Pattern box)
+: $ Norm (app[ phi / box ] (sVar box . psi)) (phi . psi)$
 = '(norm_trans appCtxL @ norm_app (norm_trans appCtxR @ norm_app norm_refl appCtxVar) norm_refl);
-theorem appctx_concat_r : $ Norm (app[ psi / box ] (phi . sVar box)) (phi . psi)$
+theorem appctx_concat_r (phi psi : Pattern box)
+: $ Norm (app[ psi / box ] (phi . sVar box)) (phi . psi)$
 = '(norm_trans appCtxR @ norm_app norm_refl appCtxVar);
 theorem propag_or_concat : $(phi1 \/ phi2) . psi ->  (phi1 . psi) \/ (phi2 . psi)$
 = '(norm (norm_imp appctx_concat_l (norm_or appctx_concat_l appctx_concat_l)) (! propag_or dummy) );
-
 
 
 --- Helpers for Kleene
@@ -78,6 +86,8 @@ theorem positive_in_top_letter {X: SVar}:
   '(positive_in_or positive_disjoint positive_disjoint);
 theorem sSubst_top_letter {X: SVar} (psi: Pattern X):
  $ Norm (s[ psi  / X ] (top_letter))  (top_letter) $ = 'sSubstitution_disjoint;
+theorem eSubst_top_letter {X: EVar} (psi: Pattern X):
+ $ Norm (e[ psi  / X ] (top_letter))  (top_letter) $ = 'eSubstitution_disjoint;
 
 --- Helpers for top_word_l
 --- TODO: Define in terms of kleene_l

--- a/21-words-helpers.mm1
+++ b/21-words-helpers.mm1
@@ -5,20 +5,20 @@ import "13-fixedpoints.mm1";
 --- Helpers for concat
 theorem positive_in_concat {X: SVar} (phi1 phi2: Pattern X)
   (h1: $ _Positive X phi1 $) (h2: $ _Positive X phi2 $): $ _Positive X (phi1 . phi2) $
-  = '(positive_in_app (positive_in_app positive_triv h1) h2);
+  = '(positive_in_app (positive_in_app positive_disjoint h1) h2);
 theorem sSubst_concat {X: SVar} (psi rho1 rho2 phi1 phi2: Pattern X)
   (h1: $ Norm (s[ psi  / X ] phi1) rho1 $)
   (h2: $ Norm (s[ psi  / X ] phi2) rho2 $):
   $ Norm (s[ psi  / X ] (phi1 . phi2))  (rho1 . rho2) $ =
-  '(_sSubst_app (_sSubst_app sSubstitution_triv h1) h2);
+  '(_sSubst_app (_sSubst_app sSubstitution_disjoint h1) h2);
 theorem sSubst_concat_l {X: SVar} (phi psi rho: Pattern X) (gamma: Pattern)
   (h: $ Norm (s[ phi / X ] psi) rho $):
   $ Norm (s[ phi / X ] (psi . gamma)) (rho . gamma) $ =
-  '(sSubst_concat h sSubstitution_triv);
+  '(sSubst_concat h sSubstitution_disjoint);
 theorem sSubst_concat_r {X: SVar} (phi psi rho: Pattern X) (gamma: Pattern)
   (h: $ Norm (s[ phi / X ] psi) rho $):
   $ Norm (s[ phi / X ] (gamma . psi)) (gamma . rho) $ =
-  '(sSubst_concat sSubstitution_triv h);
+  '(sSubst_concat sSubstitution_disjoint h);
 theorem framing_concat_l (h: $phi -> psi$): $phi . rho -> psi . rho$ =
   '(app_framing_l @ app_framing_r h);
 theorem framing_concat_r (h: $phi -> psi$): $rho . phi -> rho . psi$ =
@@ -27,15 +27,15 @@ theorem _eSubst_concat {x: EVar} (phi psi1 psi2 rho1 rho2: Pattern x)
   (h1: $ Norm (e[ phi / x ] psi1) rho1 $)
   (h2: $ Norm (e[ phi / x ] psi2) rho2 $):
   $ Norm (e[ phi / x ] (psi1 . psi2)) (rho1 . rho2) $ =
-  '(_eSubst_app (_eSubst_app eSubstitution_triv h1) h2);
+  '(_eSubst_app (_eSubst_app eSubstitution_disjoint h1) h2);
 theorem _eSubst_concat_l {x: EVar} (phi psi rho: Pattern x) (gamma: Pattern)
   (h: $ Norm (e[ phi / x ] psi) rho $):
   $ Norm (e[ phi / x ] (psi . gamma)) (rho . gamma) $ =
-  '(_eSubst_concat h eSubstitution_triv);
+  '(_eSubst_concat h eSubstitution_disjoint);
 theorem _eSubst_concat_r {x: EVar} (phi psi rho: Pattern x) (gamma: Pattern)
   (h: $ Norm (e[ phi / x ] psi) rho $):
   $ Norm (e[ phi / x ] (gamma . psi)) (gamma . rho) $ =
-  '(_eSubst_concat eSubstitution_triv h);
+  '(_eSubst_concat eSubstitution_disjoint h);
 theorem cong_of_equiv_concat_l (h: $phi1 <-> phi2$): $(phi1 . psi) <-> (phi2 . psi)$ =
   '(ibii (framing_concat_l @ anl h) (framing_concat_l @ anr h));
 theorem cong_of_equiv_concat_r (h: $phi1 <-> phi2$): $(psi . phi1) <-> (psi . phi2)$ =
@@ -60,7 +60,7 @@ theorem propag_or_concat : $(phi1 \/ phi2) . psi ->  (phi1 . psi) \/ (phi2 . psi
 theorem positive_in_kleene_r_body {X: SVar} (phi: Pattern X)
   (h: $ _Positive X phi $):
   $ _Positive X (epsilon \/ phi . sVar X) $ =
-  '(positive_in_or positive_triv @ positive_in_app (positive_in_app positive_triv h) positive_in_same_sVar);
+  '(positive_in_or positive_disjoint @ positive_in_app (positive_in_app positive_disjoint h) positive_in_same_sVar);
 theorem cong_of_equiv_kleene {X: SVar} (phi1 phi2: Pattern X)
   (h1: $ _Positive X phi1 $)
   (h2: $ _Positive X phi2 $)
@@ -75,15 +75,15 @@ theorem cong_of_equiv_kleene {X: SVar} (phi1 phi2: Pattern X)
 --- Helpers for top_letter
 theorem positive_in_top_letter {X: SVar}:
   $ _Positive X top_letter $ =
-  '(positive_in_or positive_triv positive_triv);
+  '(positive_in_or positive_disjoint positive_disjoint);
 theorem sSubst_top_letter {X: SVar} (psi: Pattern X):
- $ Norm (s[ psi  / X ] (top_letter))  (top_letter) $ = 'sSubstitution_triv;
+ $ Norm (s[ psi  / X ] (top_letter))  (top_letter) $ = 'sSubstitution_disjoint;
 
 --- Helpers for top_word_l
 --- TODO: Define in terms of kleene_l
 theorem positive_in_top_word_l_body {X: SVar}: $_Positive X (epsilon \/ sVar X . top_letter)$ =
-  '(positive_in_or positive_triv @
-    positive_in_app (positive_in_app positive_triv positive_in_same_sVar) positive_in_top_letter);
+  '(positive_in_or positive_disjoint @
+    positive_in_app (positive_in_app positive_disjoint positive_in_same_sVar) positive_in_top_letter);
 theorem kt_top_word_l {X: SVar} (psi: Pattern X) (base: $epsilon -> psi$) (rec: $psi . top_letter -> psi$): $top_word_l X -> psi$ =
   '(KT positive_in_top_word_l_body @ norm_lemma ,(propag_s_subst 'X $epsilon \/ sVar X . top_letter$) @ eori base rec);
 theorem unfold_r_top_word_l {X : SVar} (phi: Pattern) (h: $phi -> epsilon \/ top_word_l X . top_letter$) : $phi -> top_word_l X$ =
@@ -92,13 +92,13 @@ theorem unfold_r_top_word_l {X : SVar} (phi: Pattern) (h: $phi -> epsilon \/ top
 --- Helpers for top_word_r
 --- TODO: Define in terms of kleene_r
 theorem positive_in_top_word_r_body {X: SVar}: $_Positive X (epsilon \/ top_letter . sVar X)$ =
-  '(positive_in_or positive_triv @
-    positive_in_app (positive_in_app positive_triv positive_in_top_letter) positive_in_same_sVar);
+  '(positive_in_or positive_disjoint @
+    positive_in_app (positive_in_app positive_disjoint positive_in_top_letter) positive_in_same_sVar);
 theorem kt_top_word_r {X: SVar} (psi: Pattern X) (base: $epsilon -> psi$) (rec: $top_letter . psi -> psi$): $top_word_r X -> psi$ =
   '(KT positive_in_top_word_r_body @ norm_lemma ,(propag_s_subst 'X $epsilon \/ top_letter . sVar X$) @ eori base rec);
 theorem lemma_83_top_word_r_forward
     : $( epsilon \/ top_letter . top_word_r X ) -> top_word_r X $
- = '(norm_lemma (norm_sym @ _sSubst_or sSubstitution_triv @ sSubst_concat sSubstitution_triv sSubstitution_in_same_sVar ) @ pre_fixpoint positive_in_top_word_r_body ) ;
+ = '(norm_lemma (norm_sym @ _sSubst_or sSubstitution_disjoint @ sSubst_concat sSubstitution_disjoint sSubstitution_in_same_sVar ) @ pre_fixpoint positive_in_top_word_r_body ) ;
 theorem lemma_83_top_word_r_reverse
     : $ top_word_r X -> ( epsilon \/ top_letter . top_word_r X ) $
  = '(kt_top_word_r (orld id) (orrd @ framing_concat_r lemma_83_top_word_r_forward));

--- a/22-assumptions.mm0
+++ b/22-assumptions.mm0
@@ -47,10 +47,12 @@ axiom regex_eq_ewp_not_concat (Alpha Beta: Pattern):
 --- top-implies-fp
 axiom top_implies_fp_init {X: SVar} (phi: Pattern) (h: $phi . top_letter -> phi$)
   : $top_word X -> phi$;
-axiom top_implies_fp_leaf {X: SVar} (phi : Pattern) {dummy: EVar}
-  : $( ctximp_app X (sVar X . top_letter) phi dummy) . top_letter -> phi $ ;
+axiom top_implies_fp_leaf {box: SVar} (phi : Pattern box) {dummy: EVar}
+--- TODO: Add eFresh hypothesis? eFresh box phi
+  : $( ctximp_app box (sVar box . top_letter) phi dummy) . top_letter -> phi $ ;
 axiom top_implies_fp_interior  {X: SVar} {box: SVar} {dummy: EVar}
-  (fp_unf_a fp_unf_b fp_ctximp_a fp_ctximp_b : Pattern X)
+--- TODO: Add eFresh hypothesis? eFresh X { fp_unf_a fp_unf_b fp_ctximp_a fp_ctximp_b }
+  (fp_unf_a fp_unf_b fp_ctximp_a fp_ctximp_b : Pattern X box dummy)
 
   (he_a: $epsilon -> s[ (mu X (epsilon \/ ((a . fp_unf_a) \/ (b . fp_unf_b)))) / X ] fp_unf_a$)
   (he_b: $epsilon -> s[ (mu X (epsilon \/ ((a . fp_unf_a) \/ (b . fp_unf_b)))) / X ] fp_unf_b$)

--- a/22-assumptions.mm0
+++ b/22-assumptions.mm0
@@ -50,12 +50,13 @@ axiom top_implies_fp_init {X: SVar} (phi: Pattern) (h: $phi . top_letter -> phi$
 axiom top_implies_fp_leaf {X: SVar} (phi : Pattern) {dummy: EVar}
   : $( ctximp_app X (sVar X . top_letter) phi dummy) . top_letter -> phi $ ;
 axiom top_implies_fp_interior  {X: SVar} {box: SVar} {dummy: EVar}
-  (phi_a phi_b psi_a psi_b : Pattern X)
-  (he_a: $epsilon -> s[ (mu X (epsilon \/ ((a . phi_a) \/ (b . phi_b)))) / X ] phi_a$)
-  (he_b: $epsilon -> s[ (mu X (epsilon \/ ((a . phi_a) \/ (b . phi_b)))) / X ] phi_b$)
-  (ha: $(s[ (ctximp_app box (sVar box . top_letter) (mu X (epsilon \/ ((a . phi_a) \/ (b . phi_b)))) dummy) / X ] (psi_a . top_letter))
-          -> (s[ (mu X (epsilon \/ ((a . phi_a) \/ (b . phi_b)))) / X ] phi_a)$)
-  (hb: $(s[ (ctximp_app box (sVar box . top_letter) (mu X (epsilon \/ ((a . phi_a) \/ (b . phi_b)))) dummy) / X ] (psi_b . top_letter))
-          -> (s[ (mu X (epsilon \/ ((a . phi_a) \/ (b . phi_b)))) / X ] phi_b)$)
+  (fp_unf_a fp_unf_b fp_ctximp_a fp_ctximp_b : Pattern X)
+
+  (he_a: $epsilon -> s[ (mu X (epsilon \/ ((a . fp_unf_a) \/ (b . fp_unf_b)))) / X ] fp_unf_a$)
+  (he_b: $epsilon -> s[ (mu X (epsilon \/ ((a . fp_unf_a) \/ (b . fp_unf_b)))) / X ] fp_unf_b$)
+  (ha: $(s[ (ctximp_app box (sVar box . top_letter) (mu X (epsilon \/ ((a . fp_unf_a) \/ (b . fp_unf_b)))) dummy) / X ] (fp_ctximp_a . top_letter))
+          -> (s[ (mu X (epsilon \/ ((a . fp_unf_a) \/ (b . fp_unf_b)))) / X ] fp_unf_a)$)
+  (hb: $(s[ (ctximp_app box (sVar box . top_letter) (mu X (epsilon \/ ((a . fp_unf_a) \/ (b . fp_unf_b)))) dummy) / X ] (fp_ctximp_b . top_letter))
+          -> (s[ (mu X (epsilon \/ ((a . fp_unf_a) \/ (b . fp_unf_b)))) / X ] fp_unf_b)$)
   : ------------------------
-  $(mu X (epsilon \/ ((a . psi_a) \/ (b . psi_b)))) . top_letter -> (mu X (epsilon \/ ((a . phi_a) \/ (b . phi_b))))$;
+  $(mu X (epsilon \/ ((a . fp_ctximp_a) \/ (b . fp_ctximp_b)))) . top_letter -> (mu X (epsilon \/ ((a . fp_unf_a) \/ (b . fp_unf_b))))$;

--- a/23-words-theorems.mm1
+++ b/23-words-theorems.mm1
@@ -110,8 +110,8 @@ theorem regex_eq_eps_concat_r: $ Alpha . epsilon <-> Alpha $ =
     (! lemma_62 _ x));
 theorem regex_eq_double_neg: $ ~ (~ Alpha) <-> Alpha $ = '(bicom notnot);
 theorem regex_eq_bot_kleene: $ (kleene X bot) <-> epsilon $ = '(ibii
-  (rsyl (mu_framing (positive_in_or positive_triv @ positive_in_concat positive_triv positive_in_same_sVar) positive_triv (rsyl (orim2 @ norm (norm_imp_l appCtxLRVar) (! propag_bot box)) dne)) (KT positive_triv @ norm (norm_sym @ norm_imp_l sSubstitution_triv) id))
-  (epsilon_implies_kleene positive_triv));
+  (rsyl (mu_framing (positive_in_or positive_disjoint @ positive_in_concat positive_disjoint positive_in_same_sVar) positive_disjoint (rsyl (orim2 @ norm (norm_imp_l appCtxLRVar) (! propag_bot box)) dne)) (KT positive_disjoint @ norm (norm_sym @ norm_imp_l sSubstitution_disjoint) id))
+  (epsilon_implies_kleene positive_disjoint));
 
 
 --- Derivatives: "Semantic" theorems
@@ -269,9 +269,9 @@ theorem fp_implies_regex_interior {X: SVar} (phi_a phi_b: Pattern X)
     ----------------------------------------------
     $(mu X (epsilon \/ ((a . phi_a) \/ (b . phi_b)))) -> rho$ =
     '(KT
-      (positive_in_or positive_triv @ positive_in_or (positive_in_concat positive_triv posa) (positive_in_concat positive_triv posb)) @
+      (positive_in_or positive_disjoint @ positive_in_or (positive_in_concat positive_disjoint posa) (positive_in_concat positive_disjoint posb)) @
       apply_equiv (corollary_57_floor der_equality) (norm
-        (norm_imp_l @ norm_sym @ _sSubst_or sSubstitution_triv @ _sSubst_or (sSubst_concat_r norm_refl) (sSubst_concat_r norm_refl))
+        (norm_imp_l @ norm_sym @ _sSubst_or sSubstitution_disjoint @ _sSubst_or (sSubst_concat_r norm_refl) (sSubst_concat_r norm_refl))
         (orim he @ orim (framing_concat_r ha) (framing_concat_r hb))
       ));
 

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -342,8 +342,19 @@ fmod MM0 is
     op [ _ _ _ _ _ ]  : MM0SExpr MM0SExpr MM0SExpr MM0SExpr MM0SExpr  -> MM0SExpr .
     op [ _ _ _ _ _ _ ]
                       : MM0SExpr MM0SExpr MM0SExpr MM0SExpr MM0SExpr MM0SExpr  -> MM0SExpr .
-    op [ _ _ _ _ _ _ _ ]
+    op [ _ _ _ _    _ _ _ ]
                       : MM0SExpr MM0SExpr MM0SExpr MM0SExpr MM0SExpr MM0SExpr MM0SExpr  -> MM0SExpr .
+    op [ _ _ _ _    _ _ _ _     _ ]
+                      : MM0SExpr MM0SExpr MM0SExpr MM0SExpr
+                        MM0SExpr MM0SExpr MM0SExpr MM0SExpr
+                        MM0SExpr
+                     -> MM0SExpr .
+    op [ _ _ _ _    _ _ _ _     _ _ _ _     _ ]
+                      : MM0SExpr MM0SExpr MM0SExpr MM0SExpr
+                        MM0SExpr MM0SExpr MM0SExpr MM0SExpr
+                        MM0SExpr MM0SExpr MM0SExpr MM0SExpr
+                        MM0SExpr
+                     -> MM0SExpr .
 
     sort MM0Decl MM0Binder .
     op _ _ : MM0Decl MM0Decl -> MM0Decl [ctor assoc format(d n d)] .
@@ -692,6 +703,8 @@ mod PROOF-GEN is
 
 
     *** top-implies-fp *******************************************************
+    vars FpUnf FpUnfA FpUnfB FpCtximp FpCtximpA FpCtximpB : Pattern .
+
     op theorem-top-implies-fp : Pattern -> MM0Decl .
     eq theorem-top-implies-fp(Phi)
      = theorem 'top-implies-fp
@@ -705,28 +718,35 @@ mod PROOF-GEN is
              colon $ (top-word 'X) -> fp(proofHint(Phi)) $ ; .
 
     op proof-top-implies-fp : Node -> MM0SExpr .
-    eq proof-top-implies-fp(N) = [ 'top-implies-fp-init proof-top-implies-fp(fp(N), N) ] .
+    eq proof-top-implies-fp(N) = [ 'top-implies-fp-init proof-top-implies-fp((fp(N) . top-letter) -> fp(N), N) ] .
 
     op proof-top-implies-fp : Pattern Node -> MM0SExpr .
     eq proof-top-implies-fp(Phi, node(< Alpha >, eqEdge(applResult(R, Ctx, Subst), N)))
      = proof-top-implies-fp(Phi, N) .
-    eq proof-top-implies-fp(sVar X, backlink(< Alpha >))
-     = [ 'bang 'top-implies-fp-leaf 'X '- 'dummy ] .
-    eq proof-top-implies-fp(mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))) ,
-                            node(< Phi >, rlEdge(applResult('check-ewp, CtxEWP, Subst_EWP), N_EWP) ;
+    eq proof-top-implies-fp(Phi, backlink(< Alpha >))
+     = [ 'bang 'top-implies-fp-leaf 'box '- 'dummy ] .
+
+   ceq proof-top-implies-fp( ( FpCtximp . top-letter ) -> FpUnf
+                           , node(< Phi >, rlEdge(applResult('check-ewp, CtxEWP, Subst_EWP), N_EWP) ;
                                                              rlEdge(applResult('der-a,     Ctx_A, Subst_A), N_A) ;
                                                              rlEdge(applResult('der-b,     Ctx_B, Subst_B), N_B)
-                           )                      )
-     = ['top-implies-fp-interior
-         [ 'norm-lemma-r propag-sSubst(mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))), Q, Alpha)
-                         unfold-r( substitute[ mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))) / Q ] in Alpha , 'orl) ]
-         [ 'norm-lemma-r propag-sSubst(mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))), Q, Beta)
-                         unfold-r( substitute[ mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))) / Q ] in Beta  , 'orl) ]
-         [ 'norm-lemma-r propag-sSubst(mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))), Q, Alpha)
-           [ 'norm-lemma propag-sSubst([ctximp-app 'box (sVar 'box . top-letter) (mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta)))) 'dummy], Q, Alpha . top-letter) proof-top-implies-fp(Alpha, N_A) ] ]
-         [ 'norm-lemma-r propag-sSubst(mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))), Q, Beta)
-           [ 'norm-lemma propag-sSubst([ctximp-app 'box (sVar 'box . top-letter) (mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta)))) 'dummy], Q, Beta  . top-letter) proof-top-implies-fp(Beta, N_B) ] ]
-       ] .
+                           )     )
+     = [ 'bang 'top-implies-fp-interior
+         '- 'box 'dummy '-    '- '- '-
+         [ 'norm-lemma-r propag-sSubst(FpUnf, X, FpUnfA) unfold-r(substitute[ FpUnf / X ] in FpUnfA, 'orl) ]
+         [ 'norm-lemma-r propag-sSubst(FpUnf, X, FpUnfB) unfold-r(substitute[ FpUnf / X ] in FpUnfB, 'orl) ]
+         [ 'norm-lemma-r propag-sSubst(FpUnf, X, FpUnfA)
+           [ 'norm-lemma propag-sSubst([ctximp-app 'box (sVar 'box . top-letter) (FpUnf) 'dummy], X, FpCtximpA . top-letter)
+                         proof-top-implies-fp((substitute[ [ctximp-app 'box (sVar 'box . top-letter) (FpUnf) 'dummy] / X ] in (FpCtximpA . top-letter)) -> substitute[ FpUnf / X ] in FpUnfA , N_A)
+         ] ]
+         [ 'norm-lemma-r propag-sSubst(FpUnf, X, FpUnfB)
+           [ 'norm-lemma propag-sSubst([ctximp-app 'box (sVar 'box . top-letter) (FpUnf) 'dummy], X, FpCtximpB . top-letter)
+                         proof-top-implies-fp((substitute[ [ctximp-app 'box (sVar 'box . top-letter) (FpUnf) 'dummy] / X ] in (FpCtximpB . top-letter)) -> substitute[ FpUnf / X ] in FpUnfB , N_B)
+         ] ]
+       ]
+    if mu X (epsilon \/ ((a . FpCtximpA) \/ (b . FpCtximpB))) := FpCtximp
+    /\ mu X (epsilon \/ ((a . FpUnfA)    \/ (b . FpUnfB)))   := FpUnf
+     .
 
 
     *** fp-implies-regex ************************************************************
@@ -760,10 +780,18 @@ mod PROOF-GEN is
        ]
      .
 
-   --- We don't want this theorem to be public when proving the main theorem,
+   *** Public versions of Lemmas
+   --- We don't want these theorems to be public when proving the main theorem,
    --- so that we can avoid generating the fixedpoint pattern.
+   --- However, it is useful to have public versions available for debugging purposes.
+
     op theorem-fp-implies-regex-pub-mm0 : Pattern -> MM0Decl .
     op theorem-fp-implies-regex-pub : Pattern -> MM0Decl .
     eq theorem-fp-implies-regex-pub-mm0(Phi) = theorem-fp-implies-regex-mm0(Phi) .
     eq theorem-fp-implies-regex-pub(Phi)     = pub theorem-fp-implies-regex(Phi) .
+
+    op theorem-top-implies-fp-pub-mm0 : Pattern -> MM0Decl .
+    op theorem-top-implies-fp-pub : Pattern -> MM0Decl .
+    eq theorem-top-implies-fp-pub-mm0(Phi) = theorem-top-implies-fp-mm0(Phi) .
+    eq theorem-top-implies-fp-pub(Phi)     = pub theorem-top-implies-fp(Phi) .
 endm

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -616,6 +616,20 @@ mod PROOF-GEN is
     eq lift-equality-to-context(Q [ T1 , Ctx ], Q [ T1 , TOrig ], Q [ T1 , TFinal ], MMP)
      = cong-of-equiv cong-thm(Q, "-r") lift-equality-to-context(Ctx, TOrig, TFinal, MMP) .
 
+    *** eFresh ****************************************************************
+    op eFresh : Qid Pattern -> MM0SExpr .
+    eq eFresh(X, Notation)      = eFresh(X, desugar(Notation))   .
+   ceq eFresh(X, Phi)           = 'eFresh-disjoint               if not occursIn(X, Phi) .
+   ceq eFresh(X, app Phi1 Phi2) = [ 'eFresh-app eFresh(X, Phi1) eFresh(X, Phi2) ]
+                                                                 if     occursIn(X, app Phi1 Phi2) .
+   ceq eFresh(X, Phi1 -> Phi2)  = [ 'eFresh-imp eFresh(X, Phi1) eFresh(X, Phi2) ]
+                                                                 if     occursIn(X, Phi1 -> Phi2) .
+    eq eFresh(X, exists X Phi)  = 'eFresh-exists-same-var .
+   ceq eFresh(X, exists Y Phi)  = [ 'bang 'eFresh-exists '- Y '- eFresh(X, Phi) ]
+                                                                 if     occursIn(X, Phi)
+                                                                     /\ X =/= Y .
+   ceq eFresh(X, mu Y Phi)      = [ 'eFresh-mu eFresh(X, Phi) ]  if     occursIn(X, Phi) .
+
     *** sFresh ****************************************************************
     op sFresh : Qid Pattern -> MM0SExpr .
     eq sFresh(X, Notation)      = sFresh(X, desugar(Notation))   .

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -164,6 +164,10 @@ fmod PATTERN-METAMATH is
     eq minus(nil, QL) = nil .
    ceq minus(Q QL1, QL2) =   minus(QL1, QL2) if     occurs(Q, QL2) .
    ceq minus(Q QL1, QL2) = Q minus(QL1, QL2) if not occurs(Q, QL2) .
+
+    op occursIn : Qid Pattern -> Bool .
+    --- TODO: Handle EVars as well
+    eq occursIn(X, phi) = occurs(X, all-sVars(phi)) .
 endfm
 
 *** Comparing Patterns ******************************************************
@@ -229,7 +233,7 @@ mod ERE-THEOREMS is
     vars Beta  Beta1  Beta2  : Pattern .
     vars Gamma : Pattern .
     vars A B A1 A2 : Letter .
-    vars X Y : Qid . 
+    vars X Y : Qid .
 
     rl [regex_eq_der_bot]     : (derivative A bot)          => bot .
     rl [regex_eq_der_epsilon] : (derivative A epsilon)      => bot .
@@ -481,8 +485,9 @@ mod PROOF-GEN is
     vars Alpha Alpha1 Alpha2 : Pattern .
     vars Beta  Beta1  Beta2  : Pattern .
     vars Phi   Phi1   Phi2   : Pattern .
+    vars Psi   Psi1   Psi2   : Pattern .
     vars A B A1 A2 : Letter .
-
+    vars Notation : Notation .
 
     *** Proof hint generation ************************************************
 
@@ -597,23 +602,36 @@ mod PROOF-GEN is
     eq lift-equality-to-context(Q [ T1 , Ctx ], Q [ T1 , TOrig ], Q [ T1 , TFinal ], MMP)
      = cong-of-equiv cong-thm(Q, "-r") lift-equality-to-context(Ctx, TOrig, TFinal, MMP) .
 
-    *** push-s-subst *********************************************************
+    *** sFresh ****************************************************************
+    op sFresh : Qid Pattern -> MM0SExpr .
+    eq sFresh(X, Notation)      = sFresh(X, desugar(Notation))   .
+   ceq sFresh(X, Phi)           = 'sFresh-disjoint               if not occursIn(X, Phi) .
+   ceq sFresh(X, app Phi1 Phi2) = [ 'sFresh-app sFresh(X, Phi1) sFresh(X, Phi2) ]
+                                                                 if     occursIn(X, app Phi1 Phi2) .
+   ceq sFresh(X, Phi1 -> Phi2)  = [ 'sFresh-imp sFresh(X, Phi1) sFresh(X, Phi2) ]
+                                                                 if     occursIn(X, Phi1 -> Phi2) .
+   ceq sFresh(X, exists Y Phi)  = [ 'sFresh-exists sFresh(X, Phi) ]
+                                                                 if     occursIn(X, Phi) .
+   ceq sFresh(X, mu X Phi)      = 'sFresh-mu-same-var            if     occursIn(X, Phi) .
+   ceq sFresh(X, mu Y Phi)      = [ 'sFresh-mu sFresh(X, Phi) ]  if     occursIn(X, Phi)
+                                                                     /\ X =/= Y .
 
-    op propag-sSubst : Qid Pattern -> MM0SExpr .
-    eq propag-sSubst(X, bot) = 'sSubstitution-disjoint .
-    eq propag-sSubst(X, top) = 'sSubstitution-disjoint .
-    eq propag-sSubst(X, eVar X) = 'sSubstitution-disjoint .
-    eq propag-sSubst(X, sVar X) = 'sSubstitution-in-same-sVar .
-   ceq propag-sSubst(X, sVar Y) = 'sSubstitution-disjoint if X =/= Y .
-    eq propag-sSubst(X, mu X Phi) = 'sSubstitution-in-same-mu .
-   ceq propag-sSubst(X, mu Y Phi) = [ '-sSubst-mu-disjoint propag-sSubst(X, Phi) ] if X =/= Y .
-    eq propag-sSubst(X, Phi1 \/ Phi2) = [ '-sSubst-or propag-sSubst(X, Phi1) propag-sSubst(X, Phi2) ] .
+    *** propag-sSubst *********************************************************
+    op propag-sSubst : Pattern Qid Pattern -> MM0SExpr .
+    eq propag-sSubst(Psi, X, bot) = 'sSubstitution-disjoint .
+    eq propag-sSubst(Psi, X, top) = 'sSubstitution-disjoint .
+    eq propag-sSubst(Psi, X, eVar X) = 'sSubstitution-disjoint .
+    eq propag-sSubst(Psi, X, sVar X) = 'sSubstitution-in-same-sVar .
+   ceq propag-sSubst(Psi, X, sVar Y) = 'sSubstitution-disjoint if X =/= Y .
+    eq propag-sSubst(Psi, X, mu X Phi) = 'sSubstitution-in-same-mu .
+   ceq propag-sSubst(Psi, X, mu Y Phi) = [ '-sSubst-mu sFresh(Y, Psi) propag-sSubst(Psi, X, Phi) ] if X =/= Y .
+    eq propag-sSubst(Psi, X, Phi1 \/ Phi2) = [ '-sSubst-or propag-sSubst(Psi, X, Phi1) propag-sSubst(Psi, X, Phi2) ] .
 
-    eq propag-sSubst(X, Phi1 . Phi2) = [ 'sSubst-concat propag-sSubst(X, Phi1) propag-sSubst(X, Phi2) ] .
-    eq propag-sSubst(X, a) = 'sSubstitution-disjoint .
-    eq propag-sSubst(X, b) = 'sSubstitution-disjoint .
-    eq propag-sSubst(X, epsilon) = 'sSubstitution-disjoint .
-    eq propag-sSubst(X, top-letter) = 'sSubstitution-disjoint .
+    eq propag-sSubst(Psi, X, Phi1 . Phi2) = [ 'sSubst-concat propag-sSubst(Psi, X, Phi1) propag-sSubst(Psi, X, Phi2) ] .
+    eq propag-sSubst(Psi, X, a) = 'sSubstitution-disjoint .
+    eq propag-sSubst(Psi, X, b) = 'sSubstitution-disjoint .
+    eq propag-sSubst(Psi, X, epsilon) = 'sSubstitution-disjoint .
+    eq propag-sSubst(Psi, X, top-letter) = 'sSubstitution-disjoint .
 
     *** pos ******************************************************************
     op positivity : Qid Pattern -> MM0SExpr .
@@ -631,7 +649,7 @@ mod PROOF-GEN is
 
     *** unfold ***************************************************************
     op unfold-r : Pattern MM0SExpr -> MM0SExpr .
-    eq unfold-r(mu X Phi, MMP) = [ 'unfold-r positivity(X, Phi) [ 'norm-lemma-r propag-sSubst(X, Phi) MMP ] ] .
+    eq unfold-r(mu X Phi, MMP) = [ 'unfold-r positivity(X, Phi) [ 'norm-lemma-r propag-sSubst(mu X Phi, X, Phi) MMP ] ] .
 
 
     *** main-goal ************************************************************
@@ -665,6 +683,7 @@ mod PROOF-GEN is
 
     op proof-top-implies-fp : Node -> MM0SExpr .
     eq proof-top-implies-fp(N) = [ 'top-implies-fp-init proof-top-implies-fp(fp(N), N) ] .
+
     op proof-top-implies-fp : Pattern Node -> MM0SExpr .
     eq proof-top-implies-fp(Phi, node(< Alpha >, eqEdge(applResult(R, Ctx, Subst), N)))
      = proof-top-implies-fp(Phi, N) .
@@ -676,14 +695,14 @@ mod PROOF-GEN is
                                                              rlEdge(applResult('der-b,     Ctx_B, Subst_B), N_B)
                            )                      )
      = ['top-implies-fp-interior
-         [ 'norm-lemma-r propag-sSubst(Q, Alpha)
-                       unfold-r( substitute[ mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))) / Q ] in Alpha , 'orl)]
-         [ 'norm-lemma-r propag-sSubst(Q, Beta)
-                       unfold-r( substitute[ mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))) / Q ] in Beta , 'orl)]
-         [ 'norm-lemma-r propag-sSubst(Q, Alpha)
-           ['norm-lemma propag-sSubst(Q, Alpha . top-letter) proof-top-implies-fp(Alpha, N_A) ] ]
-         [ 'norm-lemma-r propag-sSubst(Q, Beta)
-           [ 'norm-lemma propag-sSubst(Q, Beta . top-letter) proof-top-implies-fp(Beta, N_B) ] ]
+         [ 'norm-lemma-r propag-sSubst(mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))), Q, Alpha)
+                         unfold-r( substitute[ mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))) / Q ] in Alpha , 'orl) ]
+         [ 'norm-lemma-r propag-sSubst(mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))), Q, Beta)
+                         unfold-r( substitute[ mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))) / Q ] in Beta  , 'orl) ]
+         [ 'norm-lemma-r propag-sSubst(mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))), Q, Alpha)
+           [ 'norm-lemma propag-sSubst([ctximp-app 'box (sVar 'box . top-letter) (mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta)))) 'dummy], Q, Alpha . top-letter) proof-top-implies-fp(Alpha, N_A) ] ]
+         [ 'norm-lemma-r propag-sSubst(mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta))), Q, Beta)
+           [ 'norm-lemma propag-sSubst([ctximp-app 'box (sVar 'box . top-letter) (mu Q (epsilon \/ ((a . Alpha) \/ (b . Beta)))) 'dummy], Q, Beta  . top-letter) proof-top-implies-fp(Beta, N_B) ] ]
        ] .
 
 
@@ -703,19 +722,18 @@ mod PROOF-GEN is
     op proof-fp-implies-regex : Node -> MM0SExpr .
     eq proof-fp-implies-regex(node(check-ewp[ epsilon ], none)) = 'id .
     eq proof-fp-implies-regex(backlink(< Alpha >)) = 'fp-implies-regex-leaf .
-    --- Context, Original Term, Continuation
     eq proof-fp-implies-regex(node(S, eqEdge(applResult(R, Ctx, Subst), N))) = [ 'apply-equiv lift-equality-to-context(Ctx, upTerm(S), upTerm(getState(N)), eq-thm(Subst, R)) proof-fp-implies-regex(N) ] .
     eq proof-fp-implies-regex(node(S, eqEdge(applResult(R, Ctx, Subst), N))) = [ 'apply-equiv lift-equality-to-context(Ctx, upTerm(S), upTerm(getState(N)), eq-thm(Subst, R)) proof-fp-implies-regex(N) ] .
     eq proof-fp-implies-regex(node(< Alpha >, rlEdge(applResult('check-ewp, CtxEWP, Subst_EWP), N_EWP) ;
                                        rlEdge(applResult('der-a,     Ctx_A, Subst_A), N_A) ;
                                        rlEdge(applResult('der-b,     Ctx_B, Subst_B), N_B)
-                      )    )
+                             )    )
      = [ 'fp-implies-regex-interior
             positivity(F(Alpha), fp(N_A))
             positivity(F(Alpha), fp(N_B))
             proof-fp-implies-regex(N_EWP)
-            [ 'norm-lemma propag-sSubst(qid(str(Alpha)), fp(N_A))  proof-fp-implies-regex(N_A)]
-            [ 'norm-lemma propag-sSubst(qid(str(Alpha)), fp(N_B))  proof-fp-implies-regex(N_B)]
+            [ 'norm-lemma propag-sSubst(Alpha, qid(str(Alpha)), fp(N_A))  proof-fp-implies-regex(N_A)]
+            [ 'norm-lemma propag-sSubst(Alpha, qid(str(Alpha)), fp(N_B))  proof-fp-implies-regex(N_B)]
        ]
      .
 

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -13,35 +13,57 @@ fmod PATTERN-METAMATH is
     op bot         : -> Pattern [ctor] .
     op exists _ _ : Qid Pattern -> Pattern [ctor] .
 
-    *** Standard sugar **********************************
-    op _ /\ _       : Pattern Pattern -> Pattern [ctor] .
-    op _ \/ _       : Pattern Pattern -> Pattern [ctor] .
-    op nu _ _       : Qid Pattern     -> Pattern [ctor] .
-    op forall _ _   : Qid Pattern     -> Pattern [ctor] .
-    op ~ _           : Pattern         -> Pattern [ctor] .
-
-    *** ERE *********************************************
-    op epsilon      :                 -> Pattern [ctor] .
-
-    --- TODO: Ideally, we'd want to be parametric over an alphabet.
-    --- However, two letters are enough to encode all words.
-    sort Letter .
-    subsort Letter < Pattern .
-    op a            :                 -> Letter [ctor] .
-    op b            :                 -> Letter [ctor] .
-    op top-letter   :                 -> Pattern [ctor] .
-    op top-word _   : Qid             -> Pattern [ctor] .
-    op [ kleene _ _ ] : Qid Pattern   -> Pattern [ctor prec 25] .
-
-    op _ . _        : Pattern Pattern -> Pattern [ctor prec 28] .
-
-    op (derivative _ _) : Pattern Pattern -> Pattern [ctor] .
-
     *** Meta variables *************************
     vars phi phi1 phi2 psi psi1 psi2 : Pattern .
     vars x y X Y Q : Qid .
     vars QL QL1 QL2 : QidList .
     vars N : Nat .
+
+    *** Notation ****************************************
+    --- The desugar operation is defined over Notation,
+    --- and allows us to replace a single notation with
+    --- its definition. Note that this isn't intended to
+    --- completely elemenate notation from a pattern
+    --- but to merely remove one layer of sugar.
+    sort Notation .
+    subsort Notation < Pattern .
+    op desugar : Notation -> Pattern .
+
+    *** Standard sugar **********************************
+    op ~ _          : Pattern         -> Notation [ctor] .
+    op _ \/ _       : Pattern Pattern -> Notation [ctor] .
+    op _ /\ _       : Pattern Pattern -> Notation [ctor] .
+    op nu _ _       : Qid Pattern     -> Notation [ctor] .
+    op forall _ _   : Qid Pattern     -> Notation [ctor] .
+
+    eq desugar(~ phi) = phi -> bot .
+    eq desugar(phi \/ psi) = ~ phi -> psi .
+    eq desugar(phi /\ psi) = ~ (phi -> ~ psi) .
+    eq desugar(nu X phi) = ~ (mu X substitute [ ~ sVar X / X ] in ~ phi) .
+    eq desugar(forall x phi) = ~ (exists x ~ phi) .
+
+    *** ERE *********************************************
+    op epsilon      :                 -> Notation [ctor] .
+    --- TODO: Ideally, we'd want to be parametric over an alphabet.
+    --- However, two letters are enough to encode all words.
+    sort Letter .
+    subsort Letter < Notation .
+    op a            :                 -> Letter [ctor] .
+    op b            :                 -> Letter [ctor] .
+    op [ kleene _ _ ] : Qid Pattern   -> Notation [ctor prec 25] .
+    op top-letter   :                 -> Notation [ctor] .
+    op kleene _ _   : Qid Pattern     -> Notation [ctor prec 25] .
+    op top-word _   : Qid             -> Notation [ctor] .
+    op _ . _        : Pattern Pattern -> Notation [ctor prec 28] .
+
+    eq desugar(epsilon) = sym 'epsilon-symbol .
+    eq desugar(a) = sym 'a-symbol .
+    eq desugar(b) = sym 'b-symbol .
+    eq desugar(top-letter) = a \/ b .
+    eq desugar([ kleene X phi ]) = mu X (epsilon \/ (phi . sVar X)) .
+    eq desugar(top-word X) = [ kleene X top-letter ] .
+
+    op (derivative _ _) : Pattern Pattern -> Pattern [ctor] .
 
     *** ERE sugar *****************************************
     --- This sugar is only for use by the user, and not for

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -29,10 +29,9 @@ fmod PATTERN-METAMATH is
     subsort Letter < Pattern .
     op a            :                 -> Letter [ctor] .
     op b            :                 -> Letter [ctor] .
-    op [ kleene _ _ ] : Qid Pattern     -> Pattern [ctor prec 25] .
     op top-letter   :                 -> Pattern [ctor] .
-    op kleene _ _   : Qid Pattern     -> Pattern [ctor prec 25] .
     op top-word _   : Qid             -> Pattern [ctor] .
+    op [ kleene _ _ ] : Qid Pattern   -> Pattern [ctor prec 25] .
 
     op _ . _        : Pattern Pattern -> Pattern [ctor prec 28] .
 

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -149,24 +149,16 @@ fmod PATTERN-METAMATH is
      = (substitute [ phi / X ] in psi1) . (substitute [ phi / X ] in psi2) .
 
     op all-sVars : Pattern -> QidList .
+    eq all-sVars(Notation) = all-sVars(desugar(Notation)) .
+    eq all-sVars(bot) = nil .
     eq all-sVars(sVar X) = X .
     eq all-sVars(eVar X) = nil .
     eq all-sVars(sym  X) = nil .
-    eq all-sVars(app phi psi) = all-sVars(phi) minus(all-sVars(psi), all-sVars(phi)) .
     eq all-sVars(phi -> psi)  = all-sVars(phi) minus(all-sVars(psi), all-sVars(phi)) .
+    eq all-sVars(app[ phi / X ] psi) = all-sVars(phi) minus(all-sVars(psi), all-sVars(phi)) .
+    eq all-sVars(app phi psi) = all-sVars(phi) minus(all-sVars(psi), all-sVars(phi)) .
     eq all-sVars(mu X phi) = X minus(all-sVars(phi), X) .
-    eq all-sVars(bot) = nil .
     eq all-sVars(exists X phi) = all-sVars(phi) .
-    eq all-sVars(~ phi) = all-sVars(phi) .
-
-    eq all-sVars(epsilon)  = nil .
-    eq all-sVars(a)  = nil .
-    eq all-sVars(b)  = nil .
-    eq all-sVars(phi \/ psi)  = all-sVars(phi) minus(all-sVars(psi), all-sVars(phi)) .
-    eq all-sVars(phi .  psi)  = all-sVars(phi) minus(all-sVars(psi), all-sVars(phi)) .
-
-    eq all-sVars([ kleene X phi ]) = X .
-    eq all-sVars(top-word X) = X .
 
     op minus : QidList QidList -> QidList .
     eq minus(nil, QL) = nil .

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -101,7 +101,7 @@ fmod PATTERN-METAMATH is
     eq substitute [ phi / X ] in sVar X = phi .
    ceq substitute [ phi / X ] in sVar Y = sVar Y if X =/= Y .
     eq substitute [ phi / X ] in mu X psi = mu X psi .
-   ceq substitute [ phi / X ] in mu Y psi = mu X (substitute [ phi / X ] in psi) if X =/= Y .
+   ceq substitute [ phi / X ] in mu Y psi = mu Y (substitute [ phi / X ] in psi) if X =/= Y .
     eq substitute [ phi / X ] in (psi1 \/ psi2) = (substitute [ phi / X ] in psi1) \/ (substitute [ phi / X ] in psi2) .
     eq substitute [ phi / X ] in epsilon = epsilon .
     eq substitute [ phi / X ] in a = a .

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -575,7 +575,7 @@ mod PROOF-GEN is
     eq propag-sSubst(X, sVar X) = 'sSubstitution-in-same-sVar .
    ceq propag-sSubst(X, sVar Y) = 'sSubstitution-triv if X =/= Y .
     eq propag-sSubst(X, mu X Phi) = 'sSubstitution-in-same-mu .
-   ceq propag-sSubst(X, mu Y Phi) = [ '-sSubst-mu propag-sSubst(X, Phi) ] if X =/= Y .
+   ceq propag-sSubst(X, mu Y Phi) = [ '-sSubst-mu-disjoint propag-sSubst(X, Phi) ] if X =/= Y .
     eq propag-sSubst(X, Phi1 \/ Phi2) = [ '-sSubst-or propag-sSubst(X, Phi1) propag-sSubst(X, Phi2) ] .
 
     eq propag-sSubst(X, Phi1 . Phi2) = [ 'sSubst-concat propag-sSubst(X, Phi1) propag-sSubst(X, Phi2) ] .

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -13,6 +13,8 @@ fmod PATTERN-METAMATH is
     op bot         : -> Pattern [ctor] .
     op exists _ _ : Qid Pattern -> Pattern [ctor] .
 
+    op app[ _ / _ ] _ : Pattern Qid Pattern -> Pattern [ctor] .
+
     *** Meta variables *************************
     vars phi phi1 phi2 psi psi1 psi2 : Pattern .
     vars x y X Y Q : Qid .

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -145,8 +145,11 @@ fmod PATTERN-METAMATH is
     eq substitute [ phi / X ] in epsilon = epsilon .
     eq substitute [ phi / X ] in a = a .
     eq substitute [ phi / X ] in b = b .
+    eq substitute [ phi / X ] in top-letter = top-letter .
     eq substitute [ phi / X ] in (psi1 . psi2)
      = (substitute [ phi / X ] in psi1) . (substitute [ phi / X ] in psi2) .
+    eq substitute [ phi / X ] in [ ctximp-app Y psi1 psi2 x ]
+     = [ ctximp-app Y (substitute [ phi / X ] in psi1) (substitute [ phi / X ] in psi2)  x ] .
 
     op all-sVars : Pattern -> QidList .
     eq all-sVars(Notation) = all-sVars(desugar(Notation)) .

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -17,9 +17,11 @@ fmod PATTERN-METAMATH is
 
     *** Meta variables *************************
     vars phi phi1 phi2 psi psi1 psi2 : Pattern .
+    vars ctx : Pattern .
     vars x y X Y Q : Qid .
     vars QL QL1 QL2 : QidList .
     vars N : Nat .
+    vars Notation : Notation .
 
     *** Notation ****************************************
     --- The desugar operation is defined over Notation,
@@ -44,6 +46,18 @@ fmod PATTERN-METAMATH is
     eq desugar(nu X phi) = ~ (mu X substitute [ ~ sVar X / X ] in ~ phi) .
     eq desugar(forall x phi) = ~ (exists x ~ phi) .
 
+    *** Definedness *************************************
+    op ceil : Pattern -> Notation [ctor] .
+    op floor : Pattern -> Notation [ctor] .
+    op _ C= _ : Pattern Pattern -> Notation .
+    op [ ctximp-app _ _ _ _ ] : Qid Pattern Pattern Qid -> Notation .
+
+    eq desugar(ceil(phi)) = app (sym 'defSym) phi .
+    eq desugar(floor(phi)) = ~ ceil(~ phi) .
+    eq desugar(phi C= psi) = floor(phi -> psi) .
+    eq desugar([ ctximp-app X ctx phi x ])
+     =  exists x (eVar x /\ ((app[ eVar x / X ] ctx) C= phi)) .
+
     *** ERE *********************************************
     op epsilon      :                 -> Notation [ctor] .
     --- TODO: Ideally, we'd want to be parametric over an alphabet.
@@ -64,6 +78,7 @@ fmod PATTERN-METAMATH is
     eq desugar(top-letter) = a \/ b .
     eq desugar([ kleene X phi ]) = mu X (epsilon \/ (phi . sVar X)) .
     eq desugar(top-word X) = [ kleene X top-letter ] .
+    eq desugar(phi . psi) = ( app ( app ( sym 'concat-symbol ) phi ) psi ) .
 
     op (derivative _ _) : Pattern Pattern -> Pattern [ctor] .
 

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -163,14 +163,25 @@ fmod PATTERN-METAMATH is
     eq all-sVars(mu X phi) = X minus(all-sVars(phi), X) .
     eq all-sVars(exists X phi) = all-sVars(phi) .
 
+    op all-eVars : Pattern -> QidList .
+    eq all-eVars(Notation) = all-eVars(desugar(Notation)) .
+    eq all-eVars(bot) = nil .
+    eq all-eVars(sVar X) = nil .
+    eq all-eVars(eVar X) = X .
+    eq all-eVars(sym  X) = nil .
+    eq all-eVars(phi -> psi)  = all-eVars(phi) minus(all-eVars(psi), all-eVars(phi)) .
+    eq all-eVars(app[ phi / X ] psi) = all-eVars(phi) minus(all-eVars(psi), all-eVars(phi)) .
+    eq all-eVars(app phi psi) = all-eVars(phi) minus(all-eVars(psi), all-eVars(phi)) .
+    eq all-eVars(mu X phi) = all-eVars(phi) .
+    eq all-eVars(exists X phi) = X minus(all-eVars(phi), X) .
+
     op minus : QidList QidList -> QidList .
     eq minus(nil, QL) = nil .
    ceq minus(Q QL1, QL2) =   minus(QL1, QL2) if     occurs(Q, QL2) .
    ceq minus(Q QL1, QL2) = Q minus(QL1, QL2) if not occurs(Q, QL2) .
 
     op occursIn : Qid Pattern -> Bool .
-    --- TODO: Handle EVars as well
-    eq occursIn(X, phi) = occurs(X, all-sVars(phi)) .
+    eq occursIn(X, phi) = occurs(X, all-sVars(phi)) or occurs(X, all-eVars(phi)) .
 endfm
 
 *** Comparing Patterns ******************************************************

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -638,9 +638,9 @@ mod PROOF-GEN is
                                                                  if     occursIn(X, app Phi1 Phi2) .
    ceq sFresh(X, Phi1 -> Phi2)  = [ 'sFresh-imp sFresh(X, Phi1) sFresh(X, Phi2) ]
                                                                  if     occursIn(X, Phi1 -> Phi2) .
-   ceq sFresh(X, exists Y Phi)  = [ 'sFresh-exists sFresh(X, Phi) ]
+   ceq sFresh(X, exists Y Phi)  = [ 'bang 'sFresh-exists '- Y '- sFresh(X, Phi) ]
                                                                  if     occursIn(X, Phi) .
-   ceq sFresh(X, mu X Phi)      = 'sFresh-mu-same-var            if     occursIn(X, Phi) .
+    eq sFresh(X, mu X Phi)      = 'sFresh-mu-same-var .
    ceq sFresh(X, mu Y Phi)      = [ 'sFresh-mu sFresh(X, Phi) ]  if     occursIn(X, Phi)
                                                                      /\ X =/= Y .
 

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -569,33 +569,33 @@ mod PROOF-GEN is
     *** push-s-subst *********************************************************
 
     op propag-sSubst : Qid Pattern -> MM0SExpr .
-    eq propag-sSubst(X, bot) = 'sSubstitution-triv .
-    eq propag-sSubst(X, top) = 'sSubstitution-triv .
-    eq propag-sSubst(X, eVar X) = 'sSubstitution-triv .
+    eq propag-sSubst(X, bot) = 'sSubstitution-disjoint .
+    eq propag-sSubst(X, top) = 'sSubstitution-disjoint .
+    eq propag-sSubst(X, eVar X) = 'sSubstitution-disjoint .
     eq propag-sSubst(X, sVar X) = 'sSubstitution-in-same-sVar .
-   ceq propag-sSubst(X, sVar Y) = 'sSubstitution-triv if X =/= Y .
+   ceq propag-sSubst(X, sVar Y) = 'sSubstitution-disjoint if X =/= Y .
     eq propag-sSubst(X, mu X Phi) = 'sSubstitution-in-same-mu .
    ceq propag-sSubst(X, mu Y Phi) = [ '-sSubst-mu-disjoint propag-sSubst(X, Phi) ] if X =/= Y .
     eq propag-sSubst(X, Phi1 \/ Phi2) = [ '-sSubst-or propag-sSubst(X, Phi1) propag-sSubst(X, Phi2) ] .
 
     eq propag-sSubst(X, Phi1 . Phi2) = [ 'sSubst-concat propag-sSubst(X, Phi1) propag-sSubst(X, Phi2) ] .
-    eq propag-sSubst(X, a) = 'sSubstitution-triv .
-    eq propag-sSubst(X, b) = 'sSubstitution-triv .
-    eq propag-sSubst(X, epsilon) = 'sSubstitution-triv .
-    eq propag-sSubst(X, top-letter) = 'sSubstitution-triv .
+    eq propag-sSubst(X, a) = 'sSubstitution-disjoint .
+    eq propag-sSubst(X, b) = 'sSubstitution-disjoint .
+    eq propag-sSubst(X, epsilon) = 'sSubstitution-disjoint .
+    eq propag-sSubst(X, top-letter) = 'sSubstitution-disjoint .
 
     *** pos ******************************************************************
     op positivity : Qid Pattern -> MM0SExpr .
     eq positivity(X, sVar X) = 'positive-in-same-sVar .
-   ceq positivity(X, sVar Y) = 'positive-triv if X =/= Y  .
+   ceq positivity(X, sVar Y) = 'positive-disjoint if X =/= Y  .
     eq positivity(X, mu X Phi) = 'positive-in-same-mu .
    ceq positivity(X, mu Y Phi) = [ 'positive-in-mu positivity(X, Phi) ]  if X =/= Y .
     eq positivity(X, [kleene X Phi]) = 'positive-in-same-mu .
    ceq positivity(X, [kleene Y Phi]) = [ 'positive-in-mu positivity(X, Phi) ]  if X =/= Y .
     eq positivity(X, Phi1 \/ Phi2) = [ 'positive-in-or positivity(X, Phi1) positivity(X, Phi2) ] .
-    eq positivity(X, epsilon) = 'positive-triv .
-    eq positivity(X, a) = 'positive-triv .
-    eq positivity(X, b) = 'positive-triv .
+    eq positivity(X, epsilon) = 'positive-disjoint .
+    eq positivity(X, a) = 'positive-disjoint .
+    eq positivity(X, b) = 'positive-disjoint .
     eq positivity(X, Phi1 . Phi2) = [ 'positive-in-concat positivity(X, Phi1) positivity(X, Phi2) ] .
 
     *** unfold ***************************************************************

--- a/regexp-proof-gen.maude
+++ b/regexp-proof-gen.maude
@@ -646,20 +646,15 @@ mod PROOF-GEN is
 
     *** propag-sSubst *********************************************************
     op propag-sSubst : Pattern Qid Pattern -> MM0SExpr .
-    eq propag-sSubst(Psi, X, bot) = 'sSubstitution-disjoint .
-    eq propag-sSubst(Psi, X, top) = 'sSubstitution-disjoint .
-    eq propag-sSubst(Psi, X, eVar X) = 'sSubstitution-disjoint .
+    eq propag-sSubst(Psi, X, Notation) = propag-sSubst(Psi, X, desugar(Notation)) .
+   ceq propag-sSubst(Psi, X, Phi) = 'sSubstitution-disjoint if not occursIn(X, Phi) .
     eq propag-sSubst(Psi, X, sVar X) = 'sSubstitution-in-same-sVar .
-   ceq propag-sSubst(Psi, X, sVar Y) = 'sSubstitution-disjoint if X =/= Y .
+    eq propag-sSubst(Psi, X, app Phi1 Phi2) = [ '-sSubst-app propag-sSubst(Psi, X, Phi1) propag-sSubst(Psi, X, Phi2) ] .
+    eq propag-sSubst(Psi, X, Phi1 -> Phi2) = [ '-sSubst-imp propag-sSubst(Psi, X, Phi1) propag-sSubst(Psi, X, Phi2) ] .
+    eq propag-sSubst(Psi, X, exists Y Phi) = [ 'bang '-sSubst-exists '- Y '- '- '- eFresh(Y, Psi) propag-sSubst(Psi, X, Phi) ] .
     eq propag-sSubst(Psi, X, mu X Phi) = 'sSubstitution-in-same-mu .
    ceq propag-sSubst(Psi, X, mu Y Phi) = [ '-sSubst-mu sFresh(Y, Psi) propag-sSubst(Psi, X, Phi) ] if X =/= Y .
-    eq propag-sSubst(Psi, X, Phi1 \/ Phi2) = [ '-sSubst-or propag-sSubst(Psi, X, Phi1) propag-sSubst(Psi, X, Phi2) ] .
 
-    eq propag-sSubst(Psi, X, Phi1 . Phi2) = [ 'sSubst-concat propag-sSubst(Psi, X, Phi1) propag-sSubst(Psi, X, Phi2) ] .
-    eq propag-sSubst(Psi, X, a) = 'sSubstitution-disjoint .
-    eq propag-sSubst(Psi, X, b) = 'sSubstitution-disjoint .
-    eq propag-sSubst(Psi, X, epsilon) = 'sSubstitution-disjoint .
-    eq propag-sSubst(Psi, X, top-letter) = 'sSubstitution-disjoint .
 
     *** pos ******************************************************************
     op positivity : Qid Pattern -> MM0SExpr .

--- a/test
+++ b/test
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 export PYTHONPYCACHEPREFIX='.build/'
+
+# TODO: Extract Maude running code from proof-gen.py and move the following
+# to test.py
+( maude test.maude  < /dev/null | grep 'result TestResult: passed' ) \
+    || { echo 'Maude unit-tests failed.';  exit 1 ; }
+
 mypy ./test.py
 exec ./test.py "$@"

--- a/test.maude
+++ b/test.maude
@@ -24,9 +24,19 @@ mod TEST is
     op unit-tests : -> TestResult .
     eq unit-tests
      =  test 'true-is-true @ true ?= true ;
-        test 'occurs-in-subset-1 @ occursIn('nCzD, sVar 'X C= sVar 'Y)        ?= false ;
-        test 'occurs-in-subset-2 @ occursIn('nCzD, sVar 'X C= sVar 'nCzD)     ?= true ;
-        test 's-subst            @ substitute[sVar 'Z / 'X] in mu 'Y sVar 'X  ?= mu 'Y sVar 'Z ;
+        test 'occurs-in-subset-1        @ occursIn('nCzD, sVar 'X C= sVar 'Y)        ?= false ;
+        test 'occurs-in-subset-2        @ occursIn('nCzD, sVar 'X C= sVar 'nCzD)     ?= true ;
+        test 'occurs-in-mu-1            @ occursIn('X, mu 'X (epsilon \/ (a . sVar 'Y \/ b . (mu 'Z (epsilon \/ (a . sVar 'Z \/ b . sVar 'Z))))))
+                                                                                     ?= true ;
+        test 'occurs-in-mu-1            @ occursIn('X, mu 'Y (epsilon \/ (a . sVar 'Y \/ b . (mu 'Z (epsilon \/ (a . sVar 'X \/ b . sVar 'Z))))))
+                                                                                     ?= true ;
+        test 's-subst                   @ substitute[sVar 'Z / 'X] in mu 'Y sVar 'X  ?= mu 'Y sVar 'Z ;
+        test 's-subst-no-desugar-1      @ substitute[ mu 'ZZ sVar 'Phi / 'ZZ ]
+                                            in [ ctximp-app 'box (sVar 'box . top-letter) (sVar 'Rho) 'dummy ]
+                                          ?=   [ ctximp-app 'box (sVar 'box . top-letter) (sVar 'Rho) 'dummy ] ;
+        test 's-subst-no-desugar-2      @ substitute[ mu 'ZZ sVar 'Phi / 'ZZ ]
+                                            in [ ctximp-app 'ZZ (sVar 'box . top-letter) (sVar 'Rho) 'dummy ]
+                                          ?=   [ ctximp-app 'ZZ (sVar 'box . top-letter) (sVar 'Rho) 'dummy ] ;
      .
 endm
 

--- a/test.maude
+++ b/test.maude
@@ -1,0 +1,28 @@
+load "./regexp-proof-gen.maude"
+
+mod TEST is
+    protecting PROOF-GEN .
+    protecting QID .
+
+    sort TestResult .
+    op passed : -> TestResult [ctor] .
+    op _ and _ : TestResult TestResult -> TestResult .
+
+    vars TR : TestResult .
+    vars TestName : Qid .
+    vars Actual Expected : Bool .
+
+    eq passed and TR =  TR .
+    eq TR and passed =  TR .
+
+    op test _ @ _ ?= _ : Qid Bool Bool -> TestResult .
+    eq test TestName @ Expected ?= Expected = passed .
+
+    op unit-tests : -> TestResult .
+    eq unit-tests
+     =      test 'true-is-true @ true ?= true
+---     and test 'false-is-true @ false ?= true
+     .
+endm
+
+reduce unit-tests .

--- a/test.maude
+++ b/test.maude
@@ -6,22 +6,27 @@ mod TEST is
 
     sort TestResult .
     op passed : -> TestResult [ctor] .
-    op _ and _ : TestResult TestResult -> TestResult .
+    op _ _ : TestResult TestResult -> TestResult [assoc] .
 
     vars TR : TestResult .
     vars TestName : Qid .
-    vars Actual Expected : Bool .
 
-    eq passed and TR =  TR .
-    eq TR and passed =  TR .
+    eq passed TR =  TR .
+    eq TR passed =  TR .
 
-    op test _ @ _ ?= _ : Qid Bool Bool -> TestResult .
-    eq test TestName @ Expected ?= Expected = passed .
+    op test _ @ _ ?= _ ; : Qid Universal Universal -> TestResult [poly(2 3)] .
+    **************************************************************************
+    *** NOTE: MAKE SURE YOU DEFINE AN EQUATION BELOW FOR ANY SORT YOU USE! ***
+    **************************************************************************
+    eq test TestName @ Expected:Bool    ?= Expected:Bool    ; = passed .
+    eq test TestName @ Expected:Pattern ?= Expected:Pattern ; = passed .
 
     op unit-tests : -> TestResult .
     eq unit-tests
-     =      test 'true-is-true @ true ?= true
----     and test 'false-is-true @ false ?= true
+     =  test 'true-is-true @ true ?= true ;
+        test 'occurs-in-subset-1 @ occursIn('nCzD, sVar 'X C= sVar 'Y)        ?= false ;
+        test 'occurs-in-subset-2 @ occursIn('nCzD, sVar 'X C= sVar 'nCzD)     ?= true ;
+        test 's-subst            @ substitute[sVar 'Z / 'X] in mu 'Y sVar 'X  ?= mu 'Y sVar 'Z ;
      .
 endm
 

--- a/test.py
+++ b/test.py
@@ -121,11 +121,16 @@ for f in sorted((glob('*.mm0') + glob('*.mm1'))):
 
 # Regular expression tests
 tests : List[TestData] = [
+    (fast, 'top-implies-fp-pub',   'example-in-paper-1',         '(a . a)* ->> (((a *) . a) + epsilon) '),
     (fast, 'main-goal',            'a-or-b-star',                '(a + b)*'),
+    (fast, 'top-implies-fp-pub',   'kleene-star-star-1',         '(a *) * ->> (a *)'),
     (fast, 'fp-implies-regex-pub', 'kleene-star-star',           '(a *) * ->> (a *)'),
     (fast, 'fp-implies-regex-pub', 'example-in-paper',           '(a . a)* ->> (((a *) . a) + epsilon) '),
+    (fast, 'top-implies-fp-pub',   'alternate-top-1',            '((a *) . b) * + (((b *) . a) *)'),
     (fast, 'fp-implies-regex-pub', 'alternate-top',              '((a *) . b) * + (((b *) . a) *)'),
+    (fast, 'top-implies-fp-pub',   'even-or-odd-1',              '((((a . a) + (a . b)) + (b . a)) + (b . b)) * + ((a + b) . (((((a . a) + (a . b)) + (b . a)) + (b . b)) *))'),
     (fast, 'fp-implies-regex-pub', 'even-or-odd',                '((((a . a) + (a . b)) + (b . a)) + (b . b)) * + ((a + b) . (((((a . a) + (a . b)) + (b . a)) + (b . b)) *))'),
+    (fast, 'top-implies-fp-pub',   'no-contains-a-or-no-only-b-1', '(~ (top . (a . top))) + ~ (b *)'),
     (fast, 'fp-implies-regex-pub', 'no-contains-a-or-no-only-b', '(~ (top . (a . top))) + ~ (b *)'),
 
     # Benchmarks from Unified Decision Procedures for Regular Expression Equivalence
@@ -135,6 +140,12 @@ tests : List[TestData] = [
     *param_test('fp-implies-regex-pub',    'eq-l-{:03d}',    'eq-l({})', fast=[1,4], slow=[2, 10, 20, 30]),
     *param_test('fp-implies-regex-pub',    'eq-r-{:03d}',    'eq-r({})', fast=[1,4], slow=[2, 10, 20, 30]),
     *param_test('fp-implies-regex-pub',   'eq-lr-{:03d}',   'eq-lr({})', fast=[1,4], slow=[2, 10, 20, 30]),
+
+    *param_test('top-implies-fp-pub', 'match-l-{:03d}-1', 'match-l({})', fast=[1,4], slow=[2, 10, 20, 30, 40, 100]),
+    *param_test('top-implies-fp-pub', 'match-r-{:03d}-1', 'match-r({})', fast=[1,4], slow=[2, 10, 20, 30]),
+    *param_test('top-implies-fp-pub',    'eq-l-{:03d}-1',    'eq-l({})', fast=[1,4], slow=[2, 10, 20, 30]),
+    *param_test('top-implies-fp-pub',    'eq-r-{:03d}-1',    'eq-r({})', fast=[1,4], slow=[2, 10, 20, 30]),
+    *param_test('top-implies-fp-pub',   'eq-lr-{:03d}-1',   'eq-lr({})', fast=[1,4], slow=[2, 10, 20, 30]),
 ]
 
 for test in tests:


### PR DESCRIPTION
This PR contains the following changes:

1. Minor bug fixes and cleanups
2. Relaxing axioms that have a disjointness requirement. For each axiom there are usually two commits: first, rename the old axiom with a `_disjoint` suffix; second,  introduce the new axiom and use it to prove the previous version.
3. Automation in Maude for proving many of this.
4. A test framework for Maude automation. I've not gone full TDD on this, but its very useful for debugging when side conditions don't apply etc.
5. Completion of top-implies-fp proof.

These are some issues that were encountered and will need to be addressed eventually.

1. The Maude `SExpr` has a constructor for each arity of SExpr needed. This is simple and works, but has reached its limits.
     * Since some theorem applications need us to enumerate the bound variables, we are using as many as 13(!) arguments.
     * It does not allow us to dynamically compute arguments to theorem applications. This is needed, list all the bound variables for the `main_goal` theorem. 
     * Its butt ugly.
     * ... unfortunately, the square bracket syntax conflicts with the syntax in Maude's META-LEVEL module, so the fix needs some additional thought. Here is what the attempted fix looked like: 

        ```diff
        -    sort MM0SExpr MM0Atom .
        -    subsort Qid < MM0Atom < MM0SExpr .
        +    sort MM0SExpr MM0Atom NeMM0SExprList MM0SExprList .
        +    subsort Qid < MM0Atom < MM0SExpr < NeMM0SExprList < MM0SExprList .
        
             --- We use square brackets instead of parens for S-Expressions since
             --- Maude treats parens specially.
        -    --- TODO: Consider using List{MM0SExpr}?
        -    op [ _ _ ]        : MM0SExpr MM0SExpr                             -> MM0SExpr .
        -    op [ _ _ _ ]      : MM0SExpr MM0SExpr MM0SExpr                    -> MM0SExpr .
        -    op [ _ _ _ _ ]    : MM0SExpr MM0SExpr MM0SExpr MM0SExpr           -> MM0SExpr .
        -    op [ _ _ _ _ _ ]  : MM0SExpr MM0SExpr MM0SExpr MM0SExpr MM0SExpr  -> MM0SExpr .
        -    op [ _ _ _ _ _ _ ]
        -                      : MM0SExpr MM0SExpr MM0SExpr MM0SExpr MM0SExpr MM0SExpr  -> MM0SExpr .
        -    op [ _ _ _ _ _ _ _ ]
        -                      : MM0SExpr MM0SExpr MM0SExpr MM0SExpr MM0SExpr MM0SExpr MM0SExpr  -> MM0SExpr .
        +    op nil : -> MM0SExprList [ctor] .
        +    op _ _ : MM0SExprList MM0SExprList -> MM0SExprList [ctor ditto].
        +    op _ _ : NeMM0SExprList MM0SExprList -> NeMM0SExprList [ctor ditto].
        +    op _ _ : MM0SExprList NeMM0SExprList -> NeMM0SExprList [ctor ditto].
        +
        +    op [ _ _ ] : Qid NeMM0SExprList -> MM0SExpr .
        
             sort MM0Decl MM0Binder .
        ```
        
2. The new Maude automation desugars notation internally, instead of calling the lemmas defined for each construct. For example, `eFresh(phi or psi)` will employ `eFresh_not` and `eFresh_implies` instead of directly calling `eFresh_or`. There is a penalty in the size of the proof, so we want to take care of this eventually.
